### PR TITLE
TFP-2067 dobbel api gjør swagger ubrukelig

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/konfig/ApplicationConfig.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/konfig/ApplicationConfig.java
@@ -40,7 +40,7 @@ public class ApplicationConfig extends Application {
 
         oas.info(info)
                 .addServersItem(new Server()
-                        .url("/fpfordel/api"));
+                        .url("/fpfordel"));
         SwaggerConfiguration oasConfig = new SwaggerConfiguration()
                 .openAPI(oas)
                 .prettyPrint(true)


### PR DESCRIPTION
Testet lokalt. Var fpfordel/api/api/ og swagger virket ikke