### PR TITLE
FIX helsesjekk skal ikke se på kodeverdi. sjekket andre queries

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/selftest/checks/DatabaseHealthCheck.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/selftest/checks/DatabaseHealthCheck.java
@@ -18,7 +18,7 @@ public class DatabaseHealthCheck extends ExtHealthCheck {
 
     private String jndiName;
 
-    private static final String SQL_QUERY = "select count(1) from KODEVERK";
+    private static final String SQL_QUERY = "select count(1) from PROSESS_TASK_TYPE";
     // må være rask, og bruke et stabilt tabell-navn
 
     private String endpoint = null; // ukjent frem til første gangs test


### PR DESCRIPTION
spør på prosess_task_type isf kodeverk. sjekket andre (native) queries