### PR TITLE
Fikser feil groupid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
             </dependency>
 
             <dependency>
-                <groupId>no.nav.foreldrepenger.felles.integrasjoner</groupId>
+                <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
                 <artifactId>sensu-klient</artifactId>
                 <version>${felles.version}</version>
             </dependency>


### PR DESCRIPTION
Skjønner ikke helt hvordan dette bygger riktig med feil GroupId men kanskje den defaulter til Parent GroupId hvis oppgitt ikke finnes.