### PR TITLE
Fikser commons security versjon - dette er midlertidig.

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -73,6 +73,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.wss4j</groupId>
+            <artifactId>wss4j-ws-security-common</artifactId>
+            <version>2.3.0</version> <!-- fjernes når fp-felles oppdateres -->
+        </dependency>
+        <dependency>
             <groupId>no.nav.vedtak.prosesstask</groupId>
             <artifactId>prosesstask-legacy</artifactId>
         </dependency>


### PR DESCRIPTION
Når dette fikser java.lang.NoClassDefFoundError: org/apache/wss4j/common/cache/WSS4JCacheUtil bør nok versjonen oppdateres i fp-felles. 