### PR TITLE
TFP-4096 fiks tema endret, saksnummer overgangsordning

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/journal/dokarkiv/model/OppdaterJournalpostRequest.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/journal/dokarkiv/model/OppdaterJournalpostRequest.java
@@ -113,13 +113,13 @@ public class OppdaterJournalpostRequest {
             return this;
         }
 
-        public Builder medSak(String fagsakId) {
-            this.request.sak = new Sak(fagsakId, Fagsystem.FPSAK.getKode(), "FAGSAK", null, null);
+        public Builder medSak(Sak sak) {
+            this.request.sak = sak;
             return this;
         }
 
         public Builder medArkivSak(String arkivSakID) {
-            this.request.sak = new Sak(null, null, "ARKIVSAK", arkivSakID, "GSAK");
+
             return this;
         }
 

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/task/joark/HentDataFraJoarkTask.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/task/joark/HentDataFraJoarkTask.java
@@ -134,7 +134,7 @@ public class HentDataFraJoarkTask extends WrappedProsessTaskHandler {
         }
         // Vesentlige mangler
         if (!Tema.FORELDRE_OG_SVANGERSKAPSPENGER.equals(dataWrapper.getTema())) {
-            LOG.warn("FPFORDEL HERK feil tema for journalpost {} tema {}",
+            LOG.info("FPFORDEL HERK feil tema for journalpost {} tema {}",
                     dataWrapper.getArkivId(), journalpost.getTema().getKode());
             return dataWrapper.nesteSteg(OpprettGSakOppgaveTask.TASKNAME);
         }


### PR DESCRIPTION
Legger på delay ved tema-endret

Midlertidig håndtering av nye/gamle saksnummer inntil arkivet har oppdatert oss (da forsvinner arkivsak mm)

Henger sammen med PR i sak, formidling, tilbake