### PR TITLE
Sjekker om forsendelse med lik ID allerede er mottatt før persisterin…

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/dokument/DokumentRepository.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/dokument/DokumentRepository.java
@@ -11,12 +11,7 @@ import java.util.UUID;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
-import javax.persistence.PersistenceException;
 import javax.persistence.Query;
-
-import org.hibernate.exception.ConstraintViolationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.fordel.kodeverdi.ArkivFilType;
 import no.nav.foreldrepenger.mottak.tjeneste.dokumentforsendelse.dto.ForsendelseStatus;
@@ -24,19 +19,18 @@ import no.nav.foreldrepenger.mottak.tjeneste.dokumentforsendelse.dto.Forsendelse
 @ApplicationScoped
 public class DokumentRepository {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DokumentRepository.class);
     private static final String LOKALT_OPPHAV = "FORDEL";
     private static final String FORSENDELSE_ID = "forsendelseId";
     private static final String HOVED_DOKUMENT = "hovedDokument";
     private static final String ARKIV_FILTYPE = "arkivFilType";
     private EntityManager entityManager;
 
-    DokumentRepository() {
-    }
-
     @Inject
     public DokumentRepository(EntityManager entityManager) {
         this.entityManager = Objects.requireNonNull(entityManager);
+    }
+
+    DokumentRepository() {
     }
 
     public void lagre(Dokument dokument) {
@@ -45,18 +39,8 @@ public class DokumentRepository {
     }
 
     public void lagre(DokumentMetadata dokumentMetadata) {
-        try {
-            entityManager.persist(dokumentMetadata);
-            entityManager.flush();
-        } catch (PersistenceException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof ConstraintViolationException c &&
-                    c.getConstraintName().contains(DokumentMetadata.UNIQUE_FORSENDELSE_ID_CONSTRAINT)) {
-                LOG.info("Forsendelse {} allerede prosessert, ignorerer denne", dokumentMetadata.getForsendelseId());
-            } else {
-                throw e;
-            }
-        }
+        entityManager.persist(dokumentMetadata);
+        entityManager.flush();
     }
 
     public Optional<Dokument> hentUnikDokument(UUID forsendelseId, boolean hovedDokument, ArkivFilType arkivFilType) {

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/tjeneste/dokumentforsendelse/DokumentforsendelseTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/tjeneste/dokumentforsendelse/DokumentforsendelseTjeneste.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.mottak.tjeneste.dokumentforsendelse;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.UUID;
 
 import no.nav.foreldrepenger.mottak.domene.dokument.Dokument;
@@ -17,4 +18,6 @@ public interface DokumentforsendelseTjeneste {
     void validerDokumentforsendelse(UUID forsendelsesId);
 
     ForsendelseStatusDto finnStatusinformasjon(UUID forsendelseId);
+
+    Optional<ForsendelseStatusDto> finnStatusinformasjonHvisEksisterer(UUID forsendelseId);
 }


### PR DESCRIPTION
Prøvd å lest meg opp litt, og det virker som det ikke er smart å håndtere exceptions så low lvl.
Entitymanager kan da være en feil state. I vårt tilfell feiler flush på lagredokumentMetadata. Når vi catcher exception er fortsatt dokumentMetadata i persistence context, og den feiler på nytt når flush i lagredokument kalles.

Sjekker nå i resttjenesten om forsendelse idn allerede eksisterer. Dette er ingen garanti for at det ikke oppstår unique-constraint exception, men tror det vil ta de aller fleste