### PR TITLE
Dokumenttype som tilleggsopplysning og 4125-komp

### DIFF
--- a/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/domene/dokument/Dokument.java
+++ b/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/domene/dokument/Dokument.java
@@ -86,6 +86,10 @@ public class Dokument extends BaseEntitet {
         return beskrivelse;
     }
 
+    public void setDokumentTypeId(DokumentTypeId dokumentTypeId) {
+        this.dokumentTypeId = dokumentTypeId;
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/journal/ArkivTjeneste.java
+++ b/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/journal/ArkivTjeneste.java
@@ -40,6 +40,7 @@ import no.nav.foreldrepenger.mottak.journal.dokarkiv.model.Dokumentvariant;
 import no.nav.foreldrepenger.mottak.journal.dokarkiv.model.OppdaterJournalpostRequest;
 import no.nav.foreldrepenger.mottak.journal.dokarkiv.model.OpprettJournalpostRequest;
 import no.nav.foreldrepenger.mottak.journal.dokarkiv.model.Sak;
+import no.nav.foreldrepenger.mottak.journal.dokarkiv.model.Tilleggsopplysning;
 import no.nav.foreldrepenger.mottak.journal.dokarkiv.model.Variantformat;
 import no.nav.foreldrepenger.mottak.journal.saf.SafTjeneste;
 import no.nav.foreldrepenger.mottak.journal.saf.model.BrukerIdType;
@@ -53,6 +54,8 @@ import no.nav.foreldrepenger.mottak.tjeneste.ArkivUtil;
 public class ArkivTjeneste {
 
     private static final Logger LOG = LoggerFactory.getLogger(ArkivTjeneste.class);
+
+    private static final String FP_DOK_TYPE = "fp_innholdtype";
 
     // Fyll på med gjengangertitler som ikke omfattes av kodeverk DokumentTypeId
     private static final Map<String, DokumentTypeId> TITTEL_MAP = Map.of(
@@ -316,6 +319,8 @@ public class ArkivTjeneste {
         request.setBruker(bruker);
         request.setAvsenderMottaker(avsender);
         request.setDokumenter(opprettDokumenter);
+        request.setTilleggsopplysninger(DokumentTypeId.UDEFINERT.equals(hovedtype) ? List.of() :
+                List.of(new Tilleggsopplysning(FP_DOK_TYPE, hovedtype.getOffisiellKode())));
 
         return request;
     }

--- a/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/journal/dokarkiv/model/OpprettJournalpostRequest.java
+++ b/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/journal/dokarkiv/model/OpprettJournalpostRequest.java
@@ -16,6 +16,7 @@ public class OpprettJournalpostRequest {
     private Sak sak;
     private Bruker bruker;
     private AvsenderMottaker avsenderMottaker;
+    private List<Tilleggsopplysning> tilleggsopplysninger;
     private List<DokumentInfoOpprett> dokumenter;
 
     public OpprettJournalpostRequest(JournalpostType journalpostType,
@@ -29,6 +30,7 @@ public class OpprettJournalpostRequest {
             Bruker bruker,
             AvsenderMottaker avsenderMottaker,
             Sak sak,
+            List<Tilleggsopplysning> tilleggsopplysninger,
             List<DokumentInfoOpprett> dokumenter) {
         this.tittel = tittel;
         this.journalpostType = journalpostType;
@@ -41,6 +43,7 @@ public class OpprettJournalpostRequest {
         this.journalfoerendeEnhet = journalfoerendeEnhet;
         this.eksternReferanseId = eksternReferanseId;
         this.datoMottatt = datoMottatt;
+        this.tilleggsopplysninger = tilleggsopplysninger;
         this.dokumenter = dokumenter;
     }
 
@@ -52,7 +55,7 @@ public class OpprettJournalpostRequest {
         this.tittel = tittel;
     }
 
-    public void setJournalposttype(JournalpostType journalpostType) {
+    public void setJournalpostType(JournalpostType journalpostType) {
         this.journalpostType = journalpostType;
     }
 
@@ -144,9 +147,17 @@ public class OpprettJournalpostRequest {
         return dokumenter;
     }
 
+    public List<Tilleggsopplysning> getTilleggsopplysninger() {
+        return tilleggsopplysninger;
+    }
+
+    public void setTilleggsopplysninger(List<Tilleggsopplysning> tilleggsopplysninger) {
+        this.tilleggsopplysninger = tilleggsopplysninger;
+    }
+
     public static OpprettJournalpostRequest nyInngående() {
         var response = new OpprettJournalpostRequest();
-        response.setJournalposttype(JournalpostType.INNGAAENDE);
+        response.setJournalpostType(JournalpostType.INNGAAENDE);
         return response;
     }
 

--- a/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/journal/dokarkiv/model/Tilleggsopplysning.java
+++ b/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/journal/dokarkiv/model/Tilleggsopplysning.java
@@ -1,0 +1,5 @@
+package no.nav.foreldrepenger.mottak.journal.dokarkiv.model;
+
+public record Tilleggsopplysning(String nokkel, String verdi) {
+
+}

--- a/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/klient/VurderFagsystemResultat.java
+++ b/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/klient/VurderFagsystemResultat.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.mottak.klient;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 import no.nav.foreldrepenger.kontrakter.fordel.BehandlendeFagsystemDto;
@@ -10,8 +9,6 @@ public class VurderFagsystemResultat {
     private boolean behandlesIVedtaksløsningen;
     private boolean sjekkMotInfotrygd;
     private boolean manuellVurdering;
-    private boolean prøvIgjen;
-    private LocalDateTime prøvIgjenTidspunkt;
     private String saksnummer;
 
     VurderFagsystemResultat(BehandlendeFagsystemDto data) {
@@ -21,8 +18,6 @@ public class VurderFagsystemResultat {
         this.behandlesIVedtaksløsningen = data.isBehandlesIVedtaksløsningen();
         this.sjekkMotInfotrygd = data.isSjekkMotInfotrygd();
         this.manuellVurdering = data.isManuellVurdering();
-        this.prøvIgjen = data.isPrøvIgjen();
-        data.getPrøvIgjenTidspunkt().ifPresent(this::setPrøvIgjenTidspunkt);
         data.getSaksnummer().ifPresent(this::setSaksnummer);
     }
 
@@ -51,22 +46,6 @@ public class VurderFagsystemResultat {
 
     public void setManuellVurdering(boolean manuellVurdering) {
         this.manuellVurdering = manuellVurdering;
-    }
-
-    public boolean isPrøvIgjen() {
-        return prøvIgjen;
-    }
-
-    public void setPrøvIgjen(boolean prøvIgjen) {
-        this.prøvIgjen = prøvIgjen;
-    }
-
-    public Optional<LocalDateTime> getPrøvIgjenTidspunkt() {
-        return Optional.ofNullable(prøvIgjenTidspunkt);
-    }
-
-    public void setPrøvIgjenTidspunkt(LocalDateTime prøvIgjenTidspunkt) {
-        this.prøvIgjenTidspunkt = prøvIgjenTidspunkt;
     }
 
     public Optional<String> getSaksnummer() {

--- a/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/tjeneste/VurderVLSaker.java
+++ b/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/tjeneste/VurderVLSaker.java
@@ -51,11 +51,7 @@ public class VurderVLSaker {
         VurderFagsystemResultat res = fagsakRestKlient.vurderFagsystem(dataWrapper);
 
         res.getSaksnummer().ifPresent(dataWrapper::setSaksnummer);
-        if (res.isPrøvIgjen()) {
-            // TODO: Gammelt IM-tull. Fjern fra kontrakter og begge applikasjoner etter prodsetting
-            throw new IllegalStateException("Utviklerfeil");
-        } else if (res.isBehandlesIVedtaksløsningen()
-                && res.getSaksnummer().isPresent()) {
+        if (res.isBehandlesIVedtaksløsningen() && res.getSaksnummer().isPresent()) {
             return new Destinasjon(ForsendelseStatus.FPSAK, res.getSaksnummer().orElseThrow());
         } else if (skalBehandlesEtterTidligereRegler(dataWrapper)) {
             return new Destinasjon(ForsendelseStatus.GOSYS, null);

--- a/fordel-domene/src/test/java/no/nav/foreldrepenger/mottak/domene/dokument/DokumentRepositoryTest.java
+++ b/fordel-domene/src/test/java/no/nav/foreldrepenger/mottak/domene/dokument/DokumentRepositoryTest.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.mottak.domene.dokument;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
@@ -95,6 +96,23 @@ class DokumentRepositoryTest {
         assertThat(repo.hentEksaktDokumentMetadata(FORSENDELSE_ID).getArkivId()).isEmpty();
         repo.oppdaterForsendelseMedArkivId(FORSENDELSE_ID, ARKIV_ID, ForsendelseStatus.FPSAK);
         assertThat(repo.hentEksaktDokumentMetadata(FORSENDELSE_ID).getArkivId()).hasValue(ARKIV_ID);
+    }
+
+    @Test
+    void oppdatere_dokument_type() {
+        var pdfSøknad = DokumentArkivTestUtil.lagDokument(FORSENDELSE_ID, DokumentTypeId.SØKNAD_SVANGERSKAPSPENGER,
+                ArkivFilType.PDFA, false);
+        repo.lagre(pdfSøknad);
+        repo.hentDokumenter(FORSENDELSE_ID).stream()
+                .filter(d ->DokumentTypeId.SØKNAD_SVANGERSKAPSPENGER.equals(d.getDokumentTypeId()))
+                .forEach(d -> {
+                    d.setDokumentTypeId(DokumentTypeId.ETTERSENDT_SØKNAD_SVANGERSKAPSPENGER_SELVSTENDIG);
+                    repo.lagre(d);
+                });
+        var dokumenter = repo.hentDokumenter(FORSENDELSE_ID);
+        assertThat(dokumenter).hasSize(1);
+        assertFalse(dokumenter.get(0).erHovedDokument());
+        assertThat(dokumenter.get(0).getDokumentTypeId()).isEqualByComparingTo(DokumentTypeId.ETTERSENDT_SØKNAD_SVANGERSKAPSPENGER_SELVSTENDIG);
     }
 
     private static DokumentMetadata dokumentMetadata(UUID forsendelseId) {

--- a/fordel-domene/src/test/java/no/nav/foreldrepenger/mottak/journal/dokarkiv/TestDokarkiv.java
+++ b/fordel-domene/src/test/java/no/nav/foreldrepenger/mottak/journal/dokarkiv/TestDokarkiv.java
@@ -133,7 +133,7 @@ class TestDokarkiv {
         r.setDokumenter(infoOpprett());
         r.setEksternReferanseId("ref");
         r.setJournalfoerendeEnhet("enhet");
-        r.setJournalposttype(JournalpostType.INNGAAENDE);
+        r.setJournalpostType(JournalpostType.INNGAAENDE);
         r.setKanal("kanal");
         r.setSak(sak());
         r.setTema("tema");

--- a/fordel-domene/src/test/java/no/nav/foreldrepenger/mottak/task/HentOgVurderVLSakTaskTest.java
+++ b/fordel-domene/src/test/java/no/nav/foreldrepenger/mottak/task/HentOgVurderVLSakTaskTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,7 +57,7 @@ class HentOgVurderVLSakTaskTest {
 
     @Test
     void neste_steg_skal_være_til_journalføring_når_vurderFagsystem_returnerer_VL_og_saksnummer() {
-        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(saksnummer, null, true, false, false, false));
+        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(saksnummer, true, false, false));
 
         var task = new HentOgVurderVLSakTask(prosessTaskRepository, new VurderVLSaker(vurderInfotrygd, fagsakRestKlientMock));
         var dataWrapper = lagDataWrapper();
@@ -70,7 +69,7 @@ class HentOgVurderVLSakTaskTest {
 
     @Test
     void neste_steg_skal_være_til_journalføring_når_vurderFagsystem_returnerer_VL_uten_saksnummer() {
-        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(null, null, true, false, false, false));
+        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(null, true, false, false));
 
         var task = new HentOgVurderVLSakTask(prosessTaskRepository, new VurderVLSaker(vurderInfotrygd, fagsakRestKlientMock));
         var dataWrapper = lagDataWrapper();
@@ -81,7 +80,7 @@ class HentOgVurderVLSakTaskTest {
 
     @Test
     void neste_steg_skal_være_hentOgVurderInfotrygd_når_vurderFagsystem_returnerer_sjekkInfotrygd() {
-        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(null, null, false, true, false, false));
+        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(null, false, true, false));
 
         var task = new HentOgVurderVLSakTask(prosessTaskRepository, new VurderVLSaker(vurderInfotrygd, fagsakRestKlientMock));
         var dataWrapper = lagDataWrapper();
@@ -92,7 +91,7 @@ class HentOgVurderVLSakTaskTest {
 
     @Test
     void neste_steg_skal_være_opprettGsakOppgave_når_vurderFagsystem_returnerer_manuell_vurdering() {
-        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(null, null, false, false, true, false));
+        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(null, false, false, true));
 
         var task = new HentOgVurderVLSakTask(prosessTaskRepository, new VurderVLSaker(vurderInfotrygd, fagsakRestKlientMock));
         var dataWrapper = lagDataWrapper();
@@ -103,7 +102,7 @@ class HentOgVurderVLSakTaskTest {
 
     @Test
     void neste_steg_skal_være_opprettGsakOppgave_når_vurderFagsystem_returnerer_VL_uten_saksnummer_og_barnet_er_født_før_19_og_annen_part_har_rett() {
-        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(null, null, true, false, false, false));
+        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(null, true, false, false));
 
         var task = new HentOgVurderVLSakTask(prosessTaskRepository, new VurderVLSaker(vurderInfotrygd, fagsakRestKlientMock));
         var dataWrapper = lagDataWrapper();
@@ -116,7 +115,7 @@ class HentOgVurderVLSakTaskTest {
 
     @Test
     void neste_steg_skal_være_til_journalføring_når_vurderFagsystem_returnerer_VL_og_saksnummer_selv_om_barnet_er_født_før_19_og_annen_part_har_rett() {
-        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(saksnummer, null, true, false, false, false));
+        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(saksnummer, true, false, false));
 
         var task = new HentOgVurderVLSakTask(prosessTaskRepository, new VurderVLSaker(vurderInfotrygd, fagsakRestKlientMock));
         var dataWrapper = lagDataWrapper();
@@ -130,7 +129,7 @@ class HentOgVurderVLSakTaskTest {
 
     @Test
     void neste_steg_skal_være_til_journalføring_når_vurderFagsystem_returnerer_VL_og_saksnummer_når_omsorg_før_19() {
-        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(saksnummer, null, true, false, false, false));
+        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(saksnummer, true, false, false));
 
         var task = new HentOgVurderVLSakTask(prosessTaskRepository, new VurderVLSaker(vurderInfotrygd, fagsakRestKlientMock));
         var dataWrapper = lagDataWrapper();
@@ -143,7 +142,7 @@ class HentOgVurderVLSakTaskTest {
 
     @Test
     void neste_steg_skal_være_tilJournalføring_når_vl_returnerer_saksnummer_for_svangerskapspenger() {
-        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(saksnummer, null, true, false, false, false));
+        when(fagsakRestKlientMock.vurderFagsystem(any())).thenReturn(lagFagsystemSvar(saksnummer, true, false, false));
 
         var task = new HentOgVurderVLSakTask(prosessTaskRepository, new VurderVLSaker(vurderInfotrygd, fagsakRestKlientMock));
 
@@ -169,15 +168,13 @@ class HentOgVurderVLSakTaskTest {
         return dataWrapper;
     }
 
-    private static VurderFagsystemResultat lagFagsystemSvar(String saksnummer, LocalDateTime prøvIgjenTidspunkt, boolean behandlesIVL,
-            boolean sjekkIT, boolean gsak, boolean prøvIgjen) {
+    private static VurderFagsystemResultat lagFagsystemSvar(String saksnummer, boolean behandlesIVL,
+                                                            boolean sjekkIT, boolean gsak) {
         VurderFagsystemResultat res = new VurderFagsystemResultat();
         res.setSaksnummer(saksnummer);
-        res.setPrøvIgjenTidspunkt(prøvIgjenTidspunkt);
         res.setBehandlesIVedtaksløsningen(behandlesIVL);
         res.setManuellVurdering(gsak);
         res.setSjekkMotInfotrygd(sjekkIT);
-        res.setPrøvIgjen(prøvIgjen);
         return res;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <prometheus.version>0.10.0</prometheus.version>
         <resteasy.version>4.6.0.Final</resteasy.version>
-        <fp-kontrakter.version>5.2.2</fp-kontrakter.version>
+        <fp-kontrakter.version>5.2.3</fp-kontrakter.version>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>navit</sonar.organization>
     </properties>


### PR DESCRIPTION
Mellomspill før 2 større PRs
- Legger dokumenttypeid som tilleggsopplysning på journalpost -> lettere å utlede senere
- Ny kontrakter uten prøvigjen
- Litt mer kompensasjon mens vi venter på 4125