### PR TITLE
ACID lagring og gjør kall til tokendings før lagring

### DIFF
--- a/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/task/SlettForsendelseTask.java
+++ b/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/task/SlettForsendelseTask.java
@@ -26,6 +26,8 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskRepository;
 public class SlettForsendelseTask extends WrappedProsessTaskHandler {
 
     public static final String TASKNAME = "fordeling.slettForsendelse";
+    public static final String FORCE_SLETT_KEY = "force.slett";
+
 
     private DokumentRepository dokumentRepository;
 
@@ -54,9 +56,10 @@ public class SlettForsendelseTask extends WrappedProsessTaskHandler {
     public MottakMeldingDataWrapper doTask(MottakMeldingDataWrapper dataWrapper) {
         Optional<UUID> forsendelseId = dataWrapper.getForsendelseId();
         if (forsendelseId.isPresent()) {
-            Optional<DokumentMetadata> metadata = dokumentRepository.hentUnikDokumentMetadata(forsendelseId.get());
-            if (metadata.isPresent() && metadata.get().getArkivId().isPresent()
-                    && (metadata.get().getStatus() != ForsendelseStatus.PENDING)) {
+            var metadata = dokumentRepository.hentUnikDokumentMetadata(forsendelseId.get());
+            if (dataWrapper.getProsessTaskData().getPropertyValue("FORCE_SLETT_KEY") != null ||
+                    (metadata.flatMap(DokumentMetadata::getArkivId).isPresent() &&
+                            metadata.filter(m -> !ForsendelseStatus.PENDING.equals(m.getStatus())).isPresent())) {
                 dokumentRepository.slettForsendelse(forsendelseId.get());
             }
         }

--- a/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/tjeneste/dokumentforsendelse/DokumentforsendelseTjeneste.java
+++ b/fordel-domene/src/main/java/no/nav/foreldrepenger/mottak/tjeneste/dokumentforsendelse/DokumentforsendelseTjeneste.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.mottak.tjeneste.dokumentforsendelse;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,11 +12,9 @@ import no.nav.foreldrepenger.mottak.tjeneste.dokumentforsendelse.dto.Forsendelse
 public interface DokumentforsendelseTjeneste {
     Duration POLL_INTERVALL = Duration.ofSeconds(1);
 
-    void nyDokumentforsendelse(DokumentMetadata metadata);
+    void lagreForsendelseValider(DokumentMetadata metadata, List<Dokument> dokumenter, Optional<String> avsenderId);
 
-    void lagreDokument(Dokument dokument);
-
-    void validerDokumentforsendelse(UUID forsendelsesId);
+    Optional<String> bestemAvsenderAktørId(String aktørId);
 
     ForsendelseStatusDto finnStatusinformasjon(UUID forsendelseId);
 

--- a/fordel-domene/src/test/java/no/nav/foreldrepenger/mottak/tjeneste/dokumentforsendelse/DokumentforsendelseTjenesteImplTest.java
+++ b/fordel-domene/src/test/java/no/nav/foreldrepenger/mottak/tjeneste/dokumentforsendelse/DokumentforsendelseTjenesteImplTest.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.mottak.tjeneste.dokumentforsendelse;
 
-import static java.util.Arrays.asList;
 import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.SØKNAD_FORELDREPENGER_FØDSEL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -13,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
@@ -79,9 +79,8 @@ class DokumentforsendelseTjenesteImplTest {
                 .setBrukerId(BRUKER_ID)
                 .setForsendelseMottatt(LocalDateTime.now())
                 .build();
-        when(dokumentRepositoryMock.hentEksaktDokumentMetadata(any())).thenReturn(metadata);
-        when(dokumentRepositoryMock.hentDokumenter(any())).thenReturn(asList(createDokument(ArkivFilType.PDFA, false)));
-        var e = assertThrows(TekniskException.class, () -> tjeneste.validerDokumentforsendelse(forsendelseId));
+        var dokumentListe = List.of(createDokument(ArkivFilType.PDFA, false));
+        var e = assertThrows(TekniskException.class, () -> tjeneste.lagreForsendelseValider(metadata, dokumentListe, Optional.empty()));
         assertTrue(e.getMessage().contains("FP-728553"));
     }
 
@@ -94,10 +93,9 @@ class DokumentforsendelseTjenesteImplTest {
                 .setSaksnummer("123")
                 .setForsendelseMottatt(LocalDateTime.now())
                 .build();
-        when(dokumentRepositoryMock.hentEksaktDokumentMetadata(any())).thenReturn(metadata);
-        when(dokumentRepositoryMock.hentDokumenter(any())).thenReturn(asList(createDokument(ArkivFilType.PDFA, false)));
+        var dokumentListe = List.of(createDokument(ArkivFilType.PDFA, false));
 
-        tjeneste.validerDokumentforsendelse(forsendelseId);
+        tjeneste.lagreForsendelseValider(metadata, dokumentListe, Optional.empty());
 
         verify(prosessTaskRepositoryMock).lagre(any(ProsessTaskData.class));
     }
@@ -111,11 +109,10 @@ class DokumentforsendelseTjenesteImplTest {
                 .setSaksnummer("123")
                 .setForsendelseMottatt(LocalDateTime.now())
                 .build();
-        when(dokumentRepositoryMock.hentEksaktDokumentMetadata(any())).thenReturn(metadata);
-        when(dokumentRepositoryMock.hentDokumenter(any()))
-                .thenReturn(asList(createDokument(ArkivFilType.PDFA, true), createDokument(ArkivFilType.XML, true)));
+        var dokumentListe = List.of(createDokument(ArkivFilType.PDFA, true), createDokument(ArkivFilType.XML, true));
 
-        tjeneste.validerDokumentforsendelse(forsendelseId);
+
+        tjeneste.lagreForsendelseValider(metadata, dokumentListe, Optional.empty());
 
         ArgumentCaptor<ProsessTaskData> prosessTaskCaptor = ArgumentCaptor.forClass(ProsessTaskData.class);
         verify(prosessTaskRepositoryMock).lagre(prosessTaskCaptor.capture());
@@ -145,11 +142,10 @@ class DokumentforsendelseTjenesteImplTest {
                 .setSaksnummer("123")
                 .setForsendelseMottatt(LocalDateTime.now())
                 .build();
-        when(dokumentRepositoryMock.hentEksaktDokumentMetadata(any())).thenReturn(metadata);
-        when(dokumentRepositoryMock.hentDokumenter(any()))
-                .thenReturn(asList(createDokument(ArkivFilType.PDFA, true), createDokument(ArkivFilType.XML, true)));
+        var dokumentListe = List.of(createDokument(ArkivFilType.PDFA, true), createDokument(ArkivFilType.XML, true));
 
-        tjeneste.validerDokumentforsendelse(forsendelseId);
+        var avsenderId = tjeneste.bestemAvsenderAktørId("1234567890");
+        tjeneste.lagreForsendelseValider(metadata, dokumentListe, avsenderId);
 
         ArgumentCaptor<ProsessTaskData> prosessTaskCaptor = ArgumentCaptor.forClass(ProsessTaskData.class);
         verify(prosessTaskRepositoryMock).lagre(prosessTaskCaptor.capture());

--- a/fordel-web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/DokumentforsendelseRestTjenesteTest.java
+++ b/fordel-web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/DokumentforsendelseRestTjenesteTest.java
@@ -243,10 +243,10 @@ class DokumentforsendelseRestTjenesteTest {
         return part;
     }
 
-    private static BodyPart mockHoveddokumentPartXml() throws Exception {
+    private BodyPart mockHoveddokumentPartXml() throws Exception {
         var part = mockBasicInputPart(Optional.of("<some ID 1>"), "hoveddokument");
         when(part.getMediaType()).thenReturn(APPLICATION_XML_TYPE);
-        when(part.getEntityAs(String.class)).thenReturn("body");
+        when(part.getEntityAs(String.class)).thenReturn(lesInnSøknad());
         return part;
     }
 
@@ -264,6 +264,12 @@ class DokumentforsendelseRestTjenesteTest {
         when(part.getEntityAs(String.class)).thenReturn("");
         when(part.getEntityAs(byte[].class)).thenReturn("body".getBytes(UTF_8));
         return part;
+    }
+
+    private String lesInnSøknad() throws Exception {
+        URL resource = this.getClass().getClassLoader().getResource("testdata/selvb-soeknad-forp.xml");
+        Path path = Paths.get(resource.toURI());
+        return new String(Files.readAllBytes(path));
     }
 
     private String byggMetadataString() throws Exception {


### PR DESCRIPTION
Når man flytter Transactional fra Rest til Service må man passe på både robusthet og ACID-egenskaper
* Alle utgående kall til resttjenester mv gjøres før lagring (både tokendings og PDL kan feile eller time ut) 
* Gjør all mapping i Rest-laget og lagre alt i en Tx - dvs ett kall.

Kall til tokendings og PDL feiler av og til -> det lå 9 søknader fra juni-september som feilet
Rekkefølgen var lagre dokument, slå opp i PDL (og tokendings) og lagring av prosesstask. 
Eksempelfeil ved oppslag: "UnknownHostException: tokendings.prod-gcp.nais.io: Temporary failure in name resolution"
Manuell gjennomgang av tilfellene ettersom noen har sendt senere søknad som er behandlet.