### PR TITLE
Fjerner loginservice som issuer fordi fpfordel mottar bare TokenX token fra selvbetjening

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{namespace}}
   labels:
     team: teamforeldrepenger
-    
+
 spec:
   accessPolicy:
      inbound:
@@ -13,8 +13,6 @@ spec:
         - application: fpsoknad-mottak
   tokenx:
     enabled: true
-  envFrom:
-    - configmap: loginservice-idporten
   image:  {{image}}
   ingresses:
 {{#each ingresses as |url|}}
@@ -49,7 +47,7 @@ spec:
     max: {{maxReplicas}}
 {{else}}
     max: 3
-{{/if}} 
+{{/if}}
     cpuThresholdPercentage: 80
   resources:
     limits:
@@ -65,13 +63,13 @@ spec:
     - kvPath: {{oraclecredskv}}
       mountPath: /var/run/secrets/nais.io/defaultDS
     - kvPath: {{oracleconfigkv}}
-      mountPath: /var/run/secrets/nais.io/defaultDSconfig   
+      mountPath: /var/run/secrets/nais.io/defaultDSconfig
     - kvPath: {{serviceuserkv}}
       mountPath: /var/run/secrets/nais.io/srvfpfordel
     - kvPath: /kv/{{cluster}}/fss/fpfordel/{{namespace}}
       mountPath: /var/run/secrets/nais.io/vault
-  env: 
+  env:
 {{#each env}}
    - name: {{@key}}
      value: "{{this}}"
-{{/each}}    
+{{/each}}

--- a/fordel-web/src/main/java/no/nav/foreldrepenger/fordel/web/server/jetty/AbstractJettyServer.java
+++ b/fordel-web/src/main/java/no/nav/foreldrepenger/fordel/web/server/jetty/AbstractJettyServer.java
@@ -62,9 +62,7 @@ abstract class AbstractJettyServer {
     // med null, settes den default til null eller binder den mot et interface?
 
     protected static final String SERVER_HOST = "0.0.0.0";
-    public static final String ACR_LEVEL4 = "acr=Level4";
     public static final String TOKENX = "tokenx";
-    public static final String IDPORTEN = "idporten";
 
     private static final Environment ENV = Environment.current();
 

--- a/fordel-web/src/main/java/no/nav/foreldrepenger/fordel/web/server/jetty/AbstractJettyServer.java
+++ b/fordel-web/src/main/java/no/nav/foreldrepenger/fordel/web/server/jetty/AbstractJettyServer.java
@@ -176,8 +176,7 @@ abstract class AbstractJettyServer {
 
     private static MultiIssuerConfiguration config() {
         return new MultiIssuerConfiguration(
-                Map.of(TOKENX, issuerProperties("token.x.well.known.url", "token.x.client.id"),
-                        IDPORTEN, issuerProperties("loginservice.idporten.discovery.url", "loginservice.idporten.audience")));
+                Map.of(TOKENX, issuerProperties("token.x.well.known.url", "token.x.client.id")));
     }
 
     private static IssuerProperties issuerProperties(String wellKnownUrl, String clientId) {

--- a/fordel-web/src/test/resources/application-local.properties
+++ b/fordel-web/src/test/resources/application-local.properties
@@ -34,10 +34,6 @@ systembruker.password=vtp
 oidc_sts.issuer.url=http://localhost:8060
 oidc.sts.issuer.url=http://localhost:8060
 oidc_sts.jwks.url=http://localhost:8060/rest/v1/sts/jwks
-# OIDC/AAD/B2C
-oidc_aad_b2c.hostUrl=http://localhost:8060/rest/AzureAd/aadb2c
-loginservice.idporten.discovery.url=http://localhost:8060/rest/AzureAd/aadb2c/v2.0/.well-known/openid-configuration
-loginservice.idporten.audience=OIDC
 # OIDC/OPENAM
 OpenIdConnect.issoHost=http://localhost:8060/rest/isso/oauth2
 OpenIdConnect.issoIssuer=https://vtp.local/issuerBehandleDokumentService


### PR DESCRIPTION
Fpsoknad-mottak sender ved tokenX token på alle innkommende requester ned mot fpfordel. Vi har derfor ikke lenger behov for å validere token fra loginservice/id-porten.
