### PR TITLE
TFP-5450 Manuell journalføring

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringRestTjeneste.java
@@ -1,14 +1,9 @@
 package no.nav.foreldrepenger.fordel.web.app.rest.journalføring;
 
-import static no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema.gjelderForeldrepenger;
 import static no.nav.foreldrepenger.fordel.web.app.rest.journalføring.ManuellJournalføringMapper.mapYtelseTypeFraDto;
-import static no.nav.foreldrepenger.fordel.web.app.rest.journalføring.ManuellJournalføringMapper.mapYtelseTypeTilDto;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Objects;
+import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.function.Function;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -24,47 +19,17 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema;
-import no.nav.foreldrepenger.fordel.kodeverdi.DokumentKategori;
-import no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId;
-import no.nav.foreldrepenger.fordel.kodeverdi.Journalposttype;
-import no.nav.foreldrepenger.fordel.kodeverdi.Journalstatus;
-import no.nav.foreldrepenger.fordel.konfig.KonfigVerdier;
 import no.nav.foreldrepenger.fordel.web.app.exceptions.FeilDto;
 import no.nav.foreldrepenger.fordel.web.server.abac.AppAbacAttributtType;
-import no.nav.foreldrepenger.journalføring.ManuellOpprettSakValidator;
-import no.nav.foreldrepenger.kontrakter.fordel.FagsakInfomasjonDto;
-import no.nav.foreldrepenger.kontrakter.fordel.SaksnummerDto;
-import no.nav.foreldrepenger.mottak.domene.MottattStrukturertDokument;
-import no.nav.foreldrepenger.mottak.domene.dokument.DokumentRepository;
-import no.nav.foreldrepenger.mottak.domene.oppgavebehandling.FerdigstillOppgaveTask;
-import no.nav.foreldrepenger.mottak.felles.MottakMeldingDataWrapper;
-import no.nav.foreldrepenger.mottak.journal.ArkivJournalpost;
-import no.nav.foreldrepenger.mottak.journal.ArkivTjeneste;
-import no.nav.foreldrepenger.mottak.klient.Fagsak;
-import no.nav.foreldrepenger.mottak.klient.OpprettSakV2Dto;
 import no.nav.foreldrepenger.mottak.klient.YtelseTypeDto;
-import no.nav.foreldrepenger.mottak.person.PersonInformasjon;
-import no.nav.foreldrepenger.mottak.task.VLKlargjørerTask;
-import no.nav.foreldrepenger.mottak.task.xml.MeldingXmlParser;
-import no.nav.foreldrepenger.mottak.tjeneste.ArkivUtil;
-import no.nav.foreldrepenger.mottak.tjeneste.VLKlargjører;
 import no.nav.foreldrepenger.typer.AktørId;
 import no.nav.foreldrepenger.typer.JournalpostId;
-import no.nav.vedtak.exception.FunksjonellException;
 import no.nav.vedtak.exception.TekniskException;
-import no.nav.vedtak.felles.integrasjon.oppgave.v1.Oppgaver;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
-import no.nav.vedtak.konfig.Tid;
 import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
 import no.nav.vedtak.sikkerhet.abac.TilpassetAbacAttributt;
@@ -82,136 +47,18 @@ import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 @ApplicationScoped
 @Transactional
 public class FerdigstillJournalføringRestTjeneste {
-    static final String JOURNALPOST_IKKE_INNGÅENDE = "Journalpost ikke Inngående";
-    static final String BRUKER_MANGLER = "Journalpost mangler knyting til bruker - prøv igjen om et halv minutt";
-    private static final Logger LOG = LoggerFactory.getLogger(FerdigstillJournalføringRestTjeneste.class);
-    private VLKlargjører klargjører;
-    private Fagsak fagsak;
-    private PersonInformasjon pdl;
-    private ArkivTjeneste arkivTjeneste;
-    private DokumentRepository dokumentRepository;
-    private Oppgaver oppgaver;
-    private ProsessTaskTjeneste taskTjeneste;
+    private FerdigstillJournalføringTjeneste journalføringTjeneste;
+
 
     protected FerdigstillJournalføringRestTjeneste() {
         // CDI proxy
     }
 
     @Inject
-    public FerdigstillJournalføringRestTjeneste(VLKlargjører klargjører,
-                                                Fagsak fagsak,
-                                                PersonInformasjon pdl,
-                                                ArkivTjeneste arkivTjeneste,
-                                                Oppgaver oppgaver,
-                                                ProsessTaskTjeneste taskTjeneste,
-                                                DokumentRepository dokumentRepository) {
-        this.klargjører = klargjører;
-        this.fagsak = fagsak;
-        this.pdl = pdl;
-        this.arkivTjeneste = arkivTjeneste;
-        this.oppgaver = oppgaver;
-        this.taskTjeneste = taskTjeneste;
-        this.dokumentRepository = dokumentRepository;
+    public FerdigstillJournalføringRestTjeneste(FerdigstillJournalføringTjeneste journalføringTjeneste) {
+        this.journalføringTjeneste = journalføringTjeneste;
     }
 
-    private static Optional<UUID> asUUID(String eksternReferanseId) {
-        try {
-            return Optional.of(UUID.fromString(eksternReferanseId));
-        } catch (Exception e) {
-            return Optional.empty();
-        }
-    }
-
-    private static BehandlingTema validerOgVelgBehandlingTema(BehandlingTema behandlingTemaFagsak,
-                                                              BehandlingTema behandlingTemaDok,
-                                                              DokumentTypeId dokumentTypeId) {
-        if (BehandlingTema.UDEFINERT.equals(behandlingTemaDok)) {
-            return behandlingTemaFagsak;
-        }
-        if (BehandlingTema.UDEFINERT.equals(behandlingTemaFagsak)) {
-            return behandlingTemaDok;
-        }
-        if (!DokumentTypeId.erSøknadType(dokumentTypeId)) {
-            return behandlingTemaFagsak;
-        }
-        if ((gjelderForeldrepenger(behandlingTemaFagsak) && !gjelderForeldrepenger(behandlingTemaDok)) || (
-            BehandlingTema.gjelderEngangsstønad(behandlingTemaFagsak) && !BehandlingTema.gjelderEngangsstønad(behandlingTemaDok)) || (
-            BehandlingTema.gjelderSvangerskapspenger(behandlingTemaFagsak) && !BehandlingTema.gjelderSvangerskapspenger(behandlingTemaDok))) {
-            throw new FunksjonellException("FP-963079", "Dokumentet samsvarer ikke med sakens type - kan ikke journalføre",
-                "Journalfør på annen sak eller opprett ny sak");
-        }
-        return BehandlingTema.ikkeSpesifikkHendelse(behandlingTemaDok) ? behandlingTemaFagsak : behandlingTemaDok;
-    }
-
-    private static void validerKanJournalføreKlageDokument(BehandlingTema behandlingTema,
-                                                           DokumentTypeId dokumentTypeId,
-                                                           DokumentKategori dokumentKategori) {
-        if (BehandlingTema.UDEFINERT.equals(behandlingTema) && (DokumentTypeId.KLAGE_DOKUMENT.equals(dokumentTypeId)
-            || DokumentKategori.KLAGE_ELLER_ANKE.equals(dokumentKategori))) {
-            throw new FunksjonellException("FP-963074", "Klager må journalføres på sak med tidligere behandling",
-                "Journalføre klagen på sak med avsluttet behandling");
-        }
-    }
-
-    private static void validerSaksnummer(String saksnummer) {
-        if (erNullEllerTom(saksnummer)) {
-            throw new TekniskException("FP-15677", lagUgyldigInputMelding("Saksnummer", saksnummer));
-        }
-    }
-
-    private static void validerJournalpostId(String journalpostId) {
-        if (erNullEllerTom(journalpostId)) {
-            throw new TekniskException("FP-15688", lagUgyldigInputMelding("JournalpostId", journalpostId));
-        }
-    }
-
-    private static void validerEnhetId(String enhetId) {
-        if (enhetId == null) {
-            throw new TekniskException("FP-15679", lagUgyldigInputMelding("EnhetId", enhetId));
-        }
-    }
-
-    private static void validerJournalposttype(Journalposttype type) {
-        if (!Journalposttype.INNGÅENDE.equals(type)) {
-            throw new TekniskException("FP-15680", lagUgyldigInputMelding("JournalpostType", JOURNALPOST_IKKE_INNGÅENDE));
-        }
-    }
-
-    private static boolean erNullEllerTom(String s) {
-        return ((s == null) || s.isEmpty());
-    }
-
-    private static void validerDokumentData(MottakMeldingDataWrapper dataWrapper,
-                                            BehandlingTema behandlingTema,
-                                            DokumentTypeId dokumentTypeId,
-                                            String imType,
-                                            LocalDate startDato) {
-        if (DokumentTypeId.INNTEKTSMELDING.equals(dokumentTypeId)) {
-            var behandlingTemaFraIM = BehandlingTema.fraTermNavn(imType);
-            if (gjelderForeldrepenger(behandlingTemaFraIM)) {
-                if (dataWrapper.getInntektsmeldingStartDato().isEmpty()) { // Kommer ingen vei uten startdato
-                    throw new FunksjonellException("FP-963076", "Inntektsmelding mangler startdato - kan ikke journalføre",
-                        "Be om ny Inntektsmelding med startdato");
-
-                } else if (!gjelderForeldrepenger(behandlingTema)) { // Prøver journalføre på annen
-                    // fagsak - ytelsetype
-                    throw new FunksjonellException("FP-963075", "Inntektsmelding årsak samsvarer ikke med sakens type - kan ikke journalføre",
-                        "Be om ny Inntektsmelding for Foreldrepenger");
-                }
-            } else if (!behandlingTemaFraIM.equals(behandlingTema)) {
-                throw new FunksjonellException("FP-963075", "Inntektsmelding årsak samsvarer ikke med sakens type - kan ikke journalføre",
-                    "Be om ny Inntektsmelding for Foreldrepenger");
-            }
-        }
-        if (gjelderForeldrepenger(behandlingTema) && startDato.isBefore(KonfigVerdier.ENDRING_BEREGNING_DATO)) {
-            throw new FunksjonellException("FP-963077", "For tidlig uttak",
-                "Søknad om uttak med oppstart i 2018 skal journalføres mot sak i Infotrygd");
-        }
-    }
-
-    private static String lagUgyldigInputMelding(String feltnavn, String verdi) {
-        return String.format("Ugyldig input: %s med verdi: %s er ugyldig input.", feltnavn, verdi);
-    }
 
     @POST
     @Path("/ferdigstill")
@@ -224,166 +71,62 @@ public class FerdigstillJournalføringRestTjeneste {
         validerJournalpostId(request.journalpostId());
         validerEnhetId(request.enhetId());
 
-        final var saksnummer = Optional.ofNullable(request.saksnummer()).orElseGet(() -> opprettSak(request.opprettSak(), request.journalpostId()));
-
-        validerSaksnummer(saksnummer);
-
-        final var journalpost = hentJournalpost(request.journalpostId());
-
-        validerJournalposttype(journalpost.getJournalposttype());
-
-        var fagsakInfomasjon = hentOgValiderFagsak(saksnummer, journalpost);
-
-        final var behandlingTemaFagsak = BehandlingTema.fraOffisiellKode(fagsakInfomasjon.getBehandlingstemaOffisiellKode());
-        final var aktørIdFagsak = fagsakInfomasjon.getAktørId();
-
-        final var dokumentTypeId = journalpost.getHovedtype();
-        final var behandlingTemaDok = ArkivUtil.behandlingTemaFraDokumentType(BehandlingTema.UDEFINERT, dokumentTypeId);
-
-        final var behandlingTema = validerOgVelgBehandlingTema(behandlingTemaFagsak, behandlingTemaDok, dokumentTypeId);
-
-        final var dokumentKategori = ArkivUtil.utledKategoriFraDokumentType(dokumentTypeId);
-        validerKanJournalføreKlageDokument(behandlingTemaFagsak, dokumentTypeId, dokumentKategori);
-
-        final var xml = hentDokumentSettMetadata(saksnummer, behandlingTema, aktørIdFagsak, journalpost);
-
-        if (Journalstatus.MOTTATT.equals(journalpost.getTilstand())) {
-            var brukDokumentTypeId = DokumentTypeId.UDEFINERT.equals(dokumentTypeId) ? DokumentTypeId.ANNET : dokumentTypeId;
-            if (!arkivTjeneste.oppdaterRettMangler(journalpost, aktørIdFagsak, behandlingTema, brukDokumentTypeId)) {
-                throw new TekniskException("FP-15678", lagUgyldigInputMelding("Bruker", BRUKER_MANGLER));
-            }
-            try {
-                arkivTjeneste.settTilleggsOpplysninger(journalpost, brukDokumentTypeId);
-            } catch (Exception e) {
-                LOG.info("FPFORDEL JOURNALFØRING Feil ved setting av tilleggsopplysninger for journalpostId {}", journalpost.getJournalpostId());
-            }
-            LOG.info("FPFORDEL JOURNALFØRING Kaller tilJournalføring"); // NOSONAR
-            try {
-                arkivTjeneste.oppdaterMedSak(journalpost.getJournalpostId(), saksnummer, aktørIdFagsak);
-                arkivTjeneste.ferdigstillJournalføring(journalpost.getJournalpostId(), request.enhetId());
-            } catch (Exception e) {
-                LOG.warn("FPFORDEL JOURNALFØRING oppdaterOgFerdigstillJournalfoering feiler for {}", journalpost.getJournalpostId(), e);
-                throw new TekniskException("FP-15689", lagUgyldigInputMelding("Bruker", BRUKER_MANGLER));
-            }
-        }
-
-        final var forsendelseId = asUUID(journalpost.getEksternReferanseId());
-
-        String eksternReferanseId = null;
-        if (DokumentTypeId.INNTEKTSMELDING.equals(dokumentTypeId)) {
-            eksternReferanseId =
-                journalpost.getEksternReferanseId() != null ? journalpost.getEksternReferanseId() : arkivTjeneste.hentEksternReferanseId(
-                    journalpost.getOriginalJournalpost()).orElse(null);
-        }
-
-        var mottattTidspunkt = Optional.ofNullable(journalpost.getDatoOpprettet()).orElseGet(LocalDateTime::now);
-
-        klargjører.klargjør(xml, saksnummer, request.journalpostId(), dokumentTypeId, mottattTidspunkt, behandlingTema, forsendelseId.orElse(null),
-            dokumentKategori, request.enhetId(), eksternReferanseId);
-
-        // For å unngå klonede journalposter fra GOSYS - de kan komme via Kafka
-        dokumentRepository.lagreJournalpostLokal(request.journalpostId(), journalpost.getKanal(), "ENDELIG", journalpost.getEksternReferanseId());
-
-        if (request.oppgaveId() != null) {
-            var oppgaveId = String.valueOf(request.oppgaveId());
-            try {
-                oppgaver.ferdigstillOppgave(oppgaveId);
-            } catch (Exception e) {
-                LOG.warn("Ferdigstilt oppgave med id {} feiler ", oppgaveId, e);
-                var ferdigstillOppgaveTask = ProsessTaskData.forProsessTask(FerdigstillOppgaveTask.class);
-                ferdigstillOppgaveTask.setProperty(FerdigstillOppgaveTask.OPPGAVEID_KEY, oppgaveId);
-                ferdigstillOppgaveTask.setCallIdFraEksisterende();
-                taskTjeneste.lagre(ferdigstillOppgaveTask);
-            }
-        }
-    }
-
-    private FagsakInfomasjonDto hentOgValiderFagsak(String saksnummer, ArkivJournalpost journalpost) {
-        // Finn sak i fpsak med samme aktør
-        final var brukerAktørId = journalpost.getBrukerAktørId();
-
-        final var fagsakFraRequestSomTrefferRettAktør = hentFagsakInfo(saksnummer).filter(
-            f -> brukerAktørId.isEmpty() || Objects.equals(f.getAktørId(), brukerAktørId.get()));
-
-        if (fagsakFraRequestSomTrefferRettAktør.isEmpty()) {
-            throw new FunksjonellException("FP-963070", "Kan ikke journalføre på saksnummer: " + saksnummer,
-                "Journalføre dokument på annen sak i VL");
-        }
-
-        LOG.info("FPFORDEL JOURNALFØRING Fant en FP-sak med saksnummer {} som har rett aktør", saksnummer);
-        return fagsakFraRequestSomTrefferRettAktør.get();
-    }
-
-    private String opprettSak(OpprettSakDto request, String journalpost) {
-        String saksnummer;
-        var opprettSak = Optional.ofNullable(request)
+        var opprettSak = Optional.ofNullable(request.opprettSak)
             .orElseThrow(() -> new TekniskException("FP-32354", "OpprettSakDto kan ikke være null ved opprettelse av en sak."));
 
-        var journalpostId = new JournalpostId(journalpost);
+        var journalpostId = new JournalpostId(request.journalpostId);
         var ytelseType = mapYtelseTypeFraDto(opprettSak.ytelseType());
         var aktørId = new AktørId(opprettSak.aktørId());
+        var oppgaveId = request.oppgaveId();
+        var saksnummer = request.saksnummer() != null ? request.saksnummer() : null;
 
-        new ManuellOpprettSakValidator(arkivTjeneste, fagsak).validerKonsistensMedSak(journalpostId, ytelseType, aktørId);
-
-        saksnummer = fagsak.opprettSak(new OpprettSakV2Dto(journalpostId.getVerdi(), mapYtelseTypeTilDto(ytelseType), aktørId.getId())).getSaksnummer();
-        return saksnummer;
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(request.enhetId, saksnummer, journalpostId, ytelseType, aktørId, oppgaveId.toString());
     }
 
-    private Optional<FagsakInfomasjonDto> hentFagsakInfo(String saksnummerFraArkiv) {
-        return fagsak.finnFagsakInfomasjon(new SaksnummerDto(saksnummerFraArkiv));
+    @POST
+    @Path("/oppdaterJournalpostTittel")
+    @Operation(description = "Opdaterer tittel på angitte dokumenter. Dersom valg av dokumentittel fører til ny journalposttittel returneres denne", tags = "Manuell journalføring", responses = {@ApiResponse(responseCode = "200", description = "Journalpost oppdatert"), @ApiResponse(responseCode = "500", description = "Feil i request", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = FeilDto.class))),})
+    @BeskyttetRessurs(actionType = ActionType.UPDATE, resourceType = ResourceType.FAGSAK)
+    public JournalpostTittelDto oppdaterJournalpost(@Parameter(description = "Trenger journalpostId og en liste med dokumentId og tittel for de dokumentene som skal oppdateres.") @NotNull @Valid
+                                                    @TilpassetAbacAttributt(supplierClass = AbacDataSupplier.class) OppdaterJournalpostMedTittelRequest journalpostRequest) {
+
+        validerJournalpostId(journalpostRequest.journalpostId());
+        var journalpostId = new JournalpostId(journalpostRequest.journalpostId());
+
+        if (journalpostRequest.dokumenter().isEmpty() ) {
+            throw new TekniskException("FpFordel: Ingen dokumenter å oppdatere for journalpostId {}",journalpostId.getVerdi() );
+        }
+        List<FerdigstillJournalføringTjeneste.DokumenterMedNyTittel> dokumenter = mapTilDokumenter(journalpostRequest.dokumenter());
+
+        Optional<String> nyJournalpostTittel = journalføringTjeneste.utledJournalpostTittelOgOppdater(dokumenter, journalpostId);
+
+        return new JournalpostTittelDto(nyJournalpostTittel.orElse(null));
     }
 
-    private ArkivJournalpost hentJournalpost(String arkivId) {
-        try {
-            return arkivTjeneste.hentArkivJournalpost(arkivId);
-        } catch (Exception e) {
-            LOG.warn("FORDEL WS fikk feil fra hentjournalpost: ", e);
-            throw new TekniskException("FP-15676", lagUgyldigInputMelding("Journalpost", "Finner ikke journalpost med id " + arkivId));
+    private List<FerdigstillJournalføringTjeneste.DokumenterMedNyTittel> mapTilDokumenter(List<OppdaterJournalpostMedTittelRequest.OppdaterDokumentRequest> dokumenter) {
+        return dokumenter.stream().map(d -> new FerdigstillJournalføringTjeneste.DokumenterMedNyTittel(d.dokumentIdDto().dokumentId(), d.tittel())).toList();
+    }
+
+    private static void validerEnhetId(String enhetId) {
+        if (enhetId == null) {
+            throw new TekniskException("FP-15679", lagUgyldigInputMelding("EnhetId", enhetId));
         }
     }
 
-    private String hentDokumentSettMetadata(String saksnummer, BehandlingTema behandlingTema, String aktørId, ArkivJournalpost journalpost) {
-        final var xml = journalpost.getStrukturertPayload();
-        if (journalpost.getInnholderStrukturertInformasjon()) {
-            // Bruker eksisterende infrastruktur for å hente ut og validere XML-data.
-            // Tasktype tilfeldig valgt
-            var prosessTaskData = ProsessTaskData.forProsessTask(VLKlargjørerTask.class);
-            var dataWrapper = new MottakMeldingDataWrapper(prosessTaskData);
-            dataWrapper.setBehandlingTema(behandlingTema);
-            dataWrapper.setSaksnummer(saksnummer);
-            dataWrapper.setAktørId(aktørId);
-            return validerXml(dataWrapper, behandlingTema, journalpost.getHovedtype(), xml);
+    private static void validerJournalpostId(String journalpostId) {
+        if (erNullEllerTom(journalpostId)) {
+            throw new TekniskException("FP-15688", lagUgyldigInputMelding("JournalpostId", journalpostId));
         }
-        return xml;
     }
 
-    private String validerXml(MottakMeldingDataWrapper dataWrapper, BehandlingTema behandlingTema, DokumentTypeId dokumentTypeId, String xml) {
-        MottattStrukturertDokument<?> mottattDokument;
-        try {
-            mottattDokument = MeldingXmlParser.unmarshallXml(xml);
-        } catch (Exception e) {
-            LOG.info("FPFORDEL JOURNALFØRING Journalpost med type {} er strukturert men er ikke gyldig XML", dokumentTypeId);
-            return null;
-        }
-        if (DokumentTypeId.FORELDREPENGER_ENDRING_SØKNAD.equals(dokumentTypeId) && !BehandlingTema.ikkeSpesifikkHendelse(behandlingTema)) {
-            dataWrapper.setBehandlingTema(BehandlingTema.FORELDREPENGER);
-        }
-        try {
-            mottattDokument.kopierTilMottakWrapper(dataWrapper, pdl::hentAktørIdForPersonIdent);
-        } catch (FunksjonellException e) {
-            // Her er det "greit" - da har man bestemt seg, men kan lage rot i saken.
-            if ("FP-401245".equals(e.getKode())) {
-                var logMessage = e.getMessage();
-                LOG.info("FPFORDEL JOURNALFØRING {}", logMessage);
-            } else {
-                throw e;
-            }
-        }
-        var imType = dataWrapper.getInntektsmeldingYtelse().orElse(null);
-        var startDato = dataWrapper.getOmsorgsovertakelsedato().orElse(dataWrapper.getFørsteUttaksdag().orElse(Tid.TIDENES_ENDE));
-        validerDokumentData(dataWrapper, behandlingTema, dokumentTypeId, imType, startDato);
-        return xml;
+    private static boolean erNullEllerTom(String s) {
+        return ((s == null) || s.isEmpty());
     }
+
+    private static String lagUgyldigInputMelding(String feltnavn, String verdi) {
+        return String.format("Ugyldig input: %s med verdi: %s er ugyldig input.", feltnavn, verdi);
+    }
+    public record JournalpostTittelDto(String journalpostTittel) {}
 
     public static class AbacDataSupplier implements Function<Object, AbacDataAttributter> {
 

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjeneste.java
@@ -1,0 +1,379 @@
+package no.nav.foreldrepenger.fordel.web.app.rest.journalføring;
+
+import static no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema.gjelderForeldrepenger;
+import static no.nav.foreldrepenger.fordel.web.app.rest.journalføring.ManuellJournalføringMapper.mapYtelseTypeTilDto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema;
+import no.nav.foreldrepenger.fordel.kodeverdi.DokumentKategori;
+import no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId;
+import no.nav.foreldrepenger.fordel.kodeverdi.Journalposttype;
+import no.nav.foreldrepenger.fordel.kodeverdi.Journalstatus;
+import no.nav.foreldrepenger.fordel.konfig.KonfigVerdier;
+import no.nav.foreldrepenger.journalføring.ManuellOpprettSakValidator;
+import no.nav.foreldrepenger.kontrakter.fordel.FagsakInfomasjonDto;
+import no.nav.foreldrepenger.kontrakter.fordel.SaksnummerDto;
+import no.nav.foreldrepenger.mottak.domene.MottattStrukturertDokument;
+import no.nav.foreldrepenger.mottak.domene.dokument.DokumentRepository;
+import no.nav.foreldrepenger.mottak.domene.oppgavebehandling.FerdigstillOppgaveTask;
+import no.nav.foreldrepenger.mottak.felles.MottakMeldingDataWrapper;
+import no.nav.foreldrepenger.mottak.journal.ArkivJournalpost;
+import no.nav.foreldrepenger.mottak.journal.ArkivTjeneste;
+import no.nav.foreldrepenger.mottak.journal.saf.DokumentInfo;
+import no.nav.foreldrepenger.mottak.klient.Fagsak;
+import no.nav.foreldrepenger.mottak.klient.FagsakYtelseTypeDto;
+import no.nav.foreldrepenger.mottak.klient.OpprettSakV2Dto;
+import no.nav.foreldrepenger.mottak.person.PersonInformasjon;
+import no.nav.foreldrepenger.mottak.task.VLKlargjørerTask;
+import no.nav.foreldrepenger.mottak.task.xml.MeldingXmlParser;
+import no.nav.foreldrepenger.mottak.tjeneste.ArkivUtil;
+import no.nav.foreldrepenger.mottak.tjeneste.VLKlargjører;
+import no.nav.foreldrepenger.typer.AktørId;
+import no.nav.foreldrepenger.typer.JournalpostId;
+import no.nav.vedtak.exception.FunksjonellException;
+import no.nav.vedtak.exception.TekniskException;
+import no.nav.vedtak.felles.integrasjon.oppgave.v1.Oppgaver;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+import no.nav.vedtak.konfig.Tid;
+
+@ApplicationScoped
+public class FerdigstillJournalføringTjeneste {
+
+    static final String BRUKER_MANGLER = "Journalpost mangler knyting til bruker - prøv igjen om et halv minutt";
+    static final String JOURNALPOST_IKKE_INNGÅENDE = "Journalpost ikke Inngående";
+    private static final Logger LOG = LoggerFactory.getLogger(FerdigstillJournalføringTjeneste.class);
+    private final VLKlargjører klargjører;
+    private final Fagsak fagsak;
+    private final PersonInformasjon pdl;
+    private final Oppgaver oppgaver;
+    private final ProsessTaskTjeneste taskTjeneste;
+    private final ArkivTjeneste arkivTjeneste;
+    private final DokumentRepository dokumentRepository;
+    @Inject
+    public FerdigstillJournalføringTjeneste(VLKlargjører klargjører,
+                                            Fagsak fagsak,
+                                            PersonInformasjon pdl,
+                                            Oppgaver oppgaver,
+                                            ProsessTaskTjeneste taskTjeneste,
+                                            ArkivTjeneste arkivTjeneste,
+                                            DokumentRepository dokumentRepository) {
+        this.klargjører = klargjører;
+        this.fagsak = fagsak;
+        this.pdl = pdl;
+        this.oppgaver = oppgaver;
+        this.taskTjeneste = taskTjeneste;
+        this.arkivTjeneste = arkivTjeneste;
+        this.dokumentRepository = dokumentRepository;
+    }
+
+    public void oppdaterJournalpostOgFerdigstill(String enhetId, String saksnummer, JournalpostId journalpostId, FagsakYtelseTypeDto ytelseType, AktørId aktørId, String oppgaveId ) {
+
+        final var journalpost = hentJournalpost(journalpostId.getVerdi());
+        validerJournalposttype(journalpost.getJournalposttype());
+
+        LOG.info("FPFORDEL RESTJOURNALFØRING: Ferdigstiller journalpostId: {}", journalpostId);
+
+        if (saksnummer == null) {
+        saksnummer = opprettSak(journalpostId, ytelseType, aktørId);
+        }
+
+        validerSaksnummer(saksnummer);
+
+        var fagsakInfomasjon = hentOgValiderFagsak(saksnummer, journalpost);
+
+        final var behandlingTemaFagsak = BehandlingTema.fraOffisiellKode(fagsakInfomasjon.getBehandlingstemaOffisiellKode());
+        final var aktørIdFagsak = fagsakInfomasjon.getAktørId();
+        final var dokumentTypeId = journalpost.getHovedtype();
+        final var behandlingTemaDok = ArkivUtil.behandlingTemaFraDokumentType(BehandlingTema.UDEFINERT, dokumentTypeId);
+        final var behandlingTema = validerOgVelgBehandlingTema(behandlingTemaFagsak, behandlingTemaDok, dokumentTypeId);
+        final var dokumentKategori = ArkivUtil.utledKategoriFraDokumentType(dokumentTypeId);
+
+        validerKanJournalføreKlageDokument(behandlingTemaFagsak, dokumentTypeId, dokumentKategori);
+
+        if (Journalstatus.MOTTATT.equals(journalpost.getTilstand())) {
+            var brukDokumentTypeId = DokumentTypeId.UDEFINERT.equals(dokumentTypeId) ? DokumentTypeId.ANNET : dokumentTypeId;
+            if (!arkivTjeneste.oppdaterRettMangler(journalpost, aktørIdFagsak, behandlingTema, brukDokumentTypeId)) {
+                throw new TekniskException("FP-15678", lagUgyldigInputMelding("Bruker", BRUKER_MANGLER));
+            }
+            try {
+                arkivTjeneste.settTilleggsOpplysninger(journalpost, brukDokumentTypeId);
+            } catch (Exception e) {
+                LOG.info("FPFORDEL RESTJOURNALFØRING: Feil ved setting av tilleggsopplysninger for journalpostId {}", journalpost.getJournalpostId());
+            }
+            LOG.info("FPFORDEL RESTJOURNALFØRING: Kaller tilJournalføring"); // NOSONAR
+            try {
+                arkivTjeneste.oppdaterMedSak(journalpost.getJournalpostId(), saksnummer, aktørIdFagsak);
+                arkivTjeneste.ferdigstillJournalføring(journalpost.getJournalpostId(), enhetId);
+            } catch (Exception e) {
+                LOG.warn("FPFORDEL RESTJOURNALFØRING: oppdaterJournalpostOgFerdigstill feiler for {}", journalpost.getJournalpostId(), e);
+                throw new TekniskException("FP-15689", lagUgyldigInputMelding("Bruker", BRUKER_MANGLER));
+            }
+        }
+
+        final var forsendelseId = asUUID(journalpost.getEksternReferanseId());
+
+        String eksternReferanseId = null;
+        if (DokumentTypeId.INNTEKTSMELDING.equals(dokumentTypeId)) {
+            eksternReferanseId =
+                journalpost.getEksternReferanseId() != null ? journalpost.getEksternReferanseId() : arkivTjeneste.hentEksternReferanseId(
+                    journalpost.getOriginalJournalpost()).orElse(null);
+        }
+
+        var mottattTidspunkt = Optional.ofNullable(journalpost.getDatoOpprettet()).orElseGet(LocalDateTime::now);
+
+        final var xml = hentDokumentSettMetadata(saksnummer, behandlingTema, aktørIdFagsak, journalpost);
+        klargjører.klargjør(xml, saksnummer, journalpostId.getVerdi(), dokumentTypeId, mottattTidspunkt, behandlingTema, forsendelseId.orElse(null),
+            dokumentKategori, enhetId, eksternReferanseId);
+
+        // For å unngå klonede journalposter fra GOSYS - de kan komme via Kafka
+        dokumentRepository.lagreJournalpostLokal(journalpost.getJournalpostId(), journalpost.getKanal(), "ENDELIG", journalpost.getEksternReferanseId());
+
+        opprettFerdigstillOppgaveTask(oppgaveId);
+    }
+
+    public Optional<String> utledJournalpostTittelOgOppdater(List<DokumenterMedNyTittel> dokumenterMedNyTittel, JournalpostId journalpostId) {
+
+        final var arkivJournalpost = hentJournalpost(journalpostId.getVerdi());
+
+        LOG.info("FPFORDEL RESTJOURNALFØRING: Oppdaterer titler for journalpostId: {}", journalpostId.getVerdi());
+
+        var opprinneligHovedType = arkivJournalpost.getHovedtype();
+        var dokumenterFraArkiv = arkivJournalpost.getOriginalJournalpost().dokumenter();
+
+        Set<DokumentTypeId> dokumenttyper = utledDokumentTyper(dokumenterMedNyTittel, dokumenterFraArkiv);
+
+        var nyHovedtype = ArkivUtil.utledHovedDokumentType(dokumenttyper);
+        var nyJournalpostTittel = skalOppdatereJournalpostTittel(nyHovedtype, opprinneligHovedType);
+        var dokumenterÅOppdatere = mapDokumenterTilOppdatering(dokumenterMedNyTittel);
+
+        arkivTjeneste.oppdaterJournalpostMedTitler(arkivJournalpost.getJournalpostId(), nyJournalpostTittel, dokumenterÅOppdatere);
+        return nyJournalpostTittel;
+    }
+
+    public record DokumenterMedNyTittel(String dokumentId, String dokumentTittel) {}
+
+    private List<no.nav.vedtak.felles.integrasjon.dokarkiv.dto.OppdaterJournalpostRequest.DokumentInfoOppdater> mapDokumenterTilOppdatering(List<DokumenterMedNyTittel> dokumenter) {
+        return dokumenter.stream()
+            .filter(dt -> dt.dokumentId() != null && dt.dokumentTittel() != null)
+            .map( dt -> new no.nav.vedtak.felles.integrasjon.dokarkiv.dto.OppdaterJournalpostRequest.DokumentInfoOppdater(dt.dokumentId(), dt.dokumentTittel(),null))
+            .toList();
+    }
+
+    private Optional<String> skalOppdatereJournalpostTittel(DokumentTypeId nyId, DokumentTypeId gammelId) {
+        return nyId.equals(gammelId) ? Optional.empty() : Optional.of(nyId.getTermNavn());
+    }
+
+    private static Set<DokumentTypeId> utledDokumentTyper(List<DokumenterMedNyTittel> dokumenterMedNyTittel,
+                                                          List<DokumentInfo> dokumenterFraArkiv) {
+        Set<DokumentTypeId> dokumentTyper = new HashSet<>();
+        Set<String> oppdatereDokIder =dokumenterMedNyTittel.stream().map(DokumenterMedNyTittel::dokumentId).collect(Collectors.toSet());
+
+        for(DokumentInfo dokumentFraArkiv : dokumenterFraArkiv) {
+            if (!oppdatereDokIder.contains(dokumentFraArkiv.dokumentInfoId())) {
+                dokumentTyper.add(DokumentTypeId.fraTermNavn(dokumentFraArkiv.tittel()));
+            }
+        }
+        for (DokumenterMedNyTittel dokumentNyTittel : dokumenterMedNyTittel) {
+            dokumentTyper.add(DokumentTypeId.fraTermNavn(dokumentNyTittel.dokumentTittel()));
+        }
+        return dokumentTyper;
+    }
+
+    private ArkivJournalpost hentJournalpost(String arkivId) {
+        try {
+            return arkivTjeneste.hentArkivJournalpost(arkivId);
+        } catch (Exception e) {
+            LOG.warn("FORDEL fikk feil fra hentjournalpost: ", e);
+            throw new TekniskException("FP-15676", lagUgyldigInputMelding("Journalpost", "Finner ikke journalpost med dokumentId " + arkivId));
+        }
+    }
+
+    private static Optional<UUID> asUUID(String eksternReferanseId) {
+        try {
+            return Optional.of(UUID.fromString(eksternReferanseId));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    String opprettSak(JournalpostId journalpostId, FagsakYtelseTypeDto ytelseType, AktørId aktørId) {
+        String saksnummer;
+
+        new ManuellOpprettSakValidator(arkivTjeneste, fagsak).validerKonsistensMedSak(journalpostId, ytelseType, aktørId);
+
+        saksnummer = fagsak.opprettSak(new OpprettSakV2Dto(journalpostId.getVerdi(), mapYtelseTypeTilDto(ytelseType), aktørId.getId())).getSaksnummer();
+        return saksnummer;
+    }
+
+
+    private static BehandlingTema validerOgVelgBehandlingTema(BehandlingTema behandlingTemaFagsak,
+                                                              BehandlingTema behandlingTemaDok,
+                                                              DokumentTypeId dokumentTypeId) {
+        if (BehandlingTema.UDEFINERT.equals(behandlingTemaDok)) {
+            return behandlingTemaFagsak;
+        }
+        if (BehandlingTema.UDEFINERT.equals(behandlingTemaFagsak)) {
+            return behandlingTemaDok;
+        }
+        if (!DokumentTypeId.erSøknadType(dokumentTypeId)) {
+            return behandlingTemaFagsak;
+        }
+        if ((gjelderForeldrepenger(behandlingTemaFagsak) && !gjelderForeldrepenger(behandlingTemaDok)) || (
+            BehandlingTema.gjelderEngangsstønad(behandlingTemaFagsak) && !BehandlingTema.gjelderEngangsstønad(behandlingTemaDok)) || (
+            BehandlingTema.gjelderSvangerskapspenger(behandlingTemaFagsak) && !BehandlingTema.gjelderSvangerskapspenger(behandlingTemaDok))) {
+            throw new FunksjonellException("FP-963079", "Dokumentet samsvarer ikke med sakens type - kan ikke journalføre",
+                "Journalfør på annen sak eller opprett ny sak");
+        }
+        return BehandlingTema.ikkeSpesifikkHendelse(behandlingTemaDok) ? behandlingTemaFagsak : behandlingTemaDok;
+    }
+
+    private static void validerKanJournalføreKlageDokument(BehandlingTema behandlingTema,
+                                                           DokumentTypeId dokumentTypeId,
+                                                           DokumentKategori dokumentKategori) {
+        if (BehandlingTema.UDEFINERT.equals(behandlingTema) && (DokumentTypeId.KLAGE_DOKUMENT.equals(dokumentTypeId)
+            || DokumentKategori.KLAGE_ELLER_ANKE.equals(dokumentKategori))) {
+            throw new FunksjonellException("FP-963074", "Klager må journalføres på sak med tidligere behandling",
+                "Journalføre klagen på sak med avsluttet behandling");
+        }
+    }
+
+    private static void validerDokumentData(MottakMeldingDataWrapper dataWrapper,
+                                            BehandlingTema behandlingTema,
+                                            DokumentTypeId dokumentTypeId,
+                                            String imType,
+                                            LocalDate startDato) {
+        if (DokumentTypeId.INNTEKTSMELDING.equals(dokumentTypeId)) {
+            var behandlingTemaFraIM = BehandlingTema.fraTermNavn(imType);
+            if (gjelderForeldrepenger(behandlingTemaFraIM)) {
+                if (dataWrapper.getInntektsmeldingStartDato().isEmpty()) { // Kommer ingen vei uten startdato
+                    throw new FunksjonellException("FP-963076", "Inntektsmelding mangler startdato - kan ikke journalføre",
+                        "Be om ny Inntektsmelding med startdato");
+
+                } else if (!gjelderForeldrepenger(behandlingTema)) { // Prøver journalføre på annen
+                    // fagsak - ytelsetype
+                    throw new FunksjonellException("FP-963075", "Inntektsmelding årsak samsvarer ikke med sakens type - kan ikke journalføre",
+                        "Be om ny Inntektsmelding for Foreldrepenger");
+                }
+            } else if (!behandlingTemaFraIM.equals(behandlingTema)) {
+                throw new FunksjonellException("FP-963075", "Inntektsmelding årsak samsvarer ikke med sakens type - kan ikke journalføre",
+                    "Be om ny Inntektsmelding for Foreldrepenger");
+            }
+        }
+        if (gjelderForeldrepenger(behandlingTema) && startDato.isBefore(KonfigVerdier.ENDRING_BEREGNING_DATO)) {
+            throw new FunksjonellException("FP-963077", "For tidlig uttak",
+                "Søknad om uttak med oppstart i 2018 skal journalføres mot sak i Infotrygd");
+        }
+    }
+
+    private static String lagUgyldigInputMelding(String feltnavn, String verdi) {
+        return String.format("Ugyldig input: %s med verdi: %s er ugyldig input.", feltnavn, verdi);
+    }
+
+    private FagsakInfomasjonDto hentOgValiderFagsak(String saksnummer, ArkivJournalpost journalpost) {
+        // Finn sak i fpsak med samme aktør
+        final var brukerAktørId = journalpost.getBrukerAktørId();
+
+        final var fagsakFraRequestSomTrefferRettAktør = hentFagsakInfo(saksnummer).filter(
+            f -> brukerAktørId.isEmpty() || Objects.equals(f.getAktørId(), brukerAktørId.get()));
+
+        if (fagsakFraRequestSomTrefferRettAktør.isEmpty()) {
+            throw new FunksjonellException("FP-963070", "Kan ikke journalføre på saksnummer: " + saksnummer,
+                "Journalføre dokument på annen sak i VL");
+        }
+
+        LOG.info("FPFORDEL RESTJOURNALFØRING: Fant en FP-sak med saksnummer {} som har rett aktør", saksnummer);
+        return fagsakFraRequestSomTrefferRettAktør.get();
+    }
+
+    private Optional<FagsakInfomasjonDto> hentFagsakInfo(String saksnummerFraArkiv) {
+        return fagsak.finnFagsakInfomasjon(new SaksnummerDto(saksnummerFraArkiv));
+    }
+
+    private String hentDokumentSettMetadata(String saksnummer, BehandlingTema behandlingTema, String aktørId, ArkivJournalpost journalpost) {
+        final var xml = journalpost.getStrukturertPayload();
+        if (journalpost.getInnholderStrukturertInformasjon()) {
+            // Bruker eksisterende infrastruktur for å hente ut og validere XML-data.
+            // Tasktype tilfeldig valgt
+            var prosessTaskData = ProsessTaskData.forProsessTask(VLKlargjørerTask.class);
+            var dataWrapper = new MottakMeldingDataWrapper(prosessTaskData);
+            dataWrapper.setBehandlingTema(behandlingTema);
+            dataWrapper.setSaksnummer(saksnummer);
+            dataWrapper.setAktørId(aktørId);
+            return validerXml(dataWrapper, behandlingTema, journalpost.getHovedtype(), xml);
+        }
+        return xml;
+    }
+
+    private String validerXml(MottakMeldingDataWrapper dataWrapper, BehandlingTema behandlingTema, DokumentTypeId dokumentTypeId, String xml) {
+        MottattStrukturertDokument<?> mottattDokument;
+        try {
+            mottattDokument = MeldingXmlParser.unmarshallXml(xml);
+        } catch (Exception e) {
+            LOG.info("FPFORDEL RESTJOURNALFØRING: Journalpost med type {} er strukturert men er ikke gyldig XML", dokumentTypeId);
+            return null;
+        }
+        if (DokumentTypeId.FORELDREPENGER_ENDRING_SØKNAD.equals(dokumentTypeId) && !BehandlingTema.ikkeSpesifikkHendelse(behandlingTema)) {
+            dataWrapper.setBehandlingTema(BehandlingTema.FORELDREPENGER);
+        }
+        try {
+            mottattDokument.kopierTilMottakWrapper(dataWrapper, pdl::hentAktørIdForPersonIdent);
+        } catch (FunksjonellException e) {
+            // Her er det "greit" - da har man bestemt seg, men kan lage rot i saken.
+            if ("FP-401245".equals(e.getKode())) {
+                var logMessage = e.getMessage();
+                LOG.info("FPFORDEL RESTJOURNALFØRING: {}", logMessage);
+            } else {
+                throw e;
+            }
+        }
+        var imType = dataWrapper.getInntektsmeldingYtelse().orElse(null);
+        var startDato = dataWrapper.getOmsorgsovertakelsedato().orElse(dataWrapper.getFørsteUttaksdag().orElse(Tid.TIDENES_ENDE));
+        validerDokumentData(dataWrapper, behandlingTema, dokumentTypeId, imType, startDato);
+        return xml;
+    }
+
+    private static void validerSaksnummer(String saksnummer) {
+        if (erNullEllerTom(saksnummer)) {
+            throw new TekniskException("FP-15677", lagUgyldigInputMelding("Saksnummer", saksnummer));
+        }
+    }
+    private static boolean erNullEllerTom(String s) {
+        return ((s == null) || s.isEmpty());
+    }
+
+    private static void validerJournalposttype(Journalposttype type) {
+        if (!Journalposttype.INNGÅENDE.equals(type)) {
+            throw new TekniskException("FP-15680", lagUgyldigInputMelding("JournalpostType", JOURNALPOST_IKKE_INNGÅENDE));
+        }
+    }
+
+    void opprettFerdigstillOppgaveTask(String oppgaveId) {
+        if (oppgaveId != null) {
+            try {
+                oppgaver.ferdigstillOppgave(oppgaveId);
+            } catch (Exception e) {
+                LOG.warn("FPFORDEL RESTJOURNALFØRING: Ferdigstilt oppgave med dokumentId {} feiler ", oppgaveId, e);
+                var ferdigstillOppgaveTask = ProsessTaskData.forProsessTask(FerdigstillOppgaveTask.class);
+                ferdigstillOppgaveTask.setProperty(FerdigstillOppgaveTask.OPPGAVEID_KEY, oppgaveId);
+                ferdigstillOppgaveTask.setCallIdFraEksisterende();
+                taskTjeneste.lagre(ferdigstillOppgaveTask);
+            }
+        }
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/ManuellJournalføringRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/ManuellJournalføringRestTjeneste.java
@@ -56,11 +56,16 @@ import no.nav.vedtak.sikkerhet.abac.beskyttet.ActionType;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 @Path(ManuellJournalføringRestTjeneste.JOURNALFOERING_PATH)
 @RequestScoped
 @Transactional
 public class ManuellJournalføringRestTjeneste {
     private static final Environment ENV = Environment.current();
+
+    private static final Logger LOG = LoggerFactory.getLogger(ManuellJournalføringRestTjeneste.class);
 
     public static final String JOURNALFOERING_PATH = "/journalfoering";
     private static final String DOKUMENT_HENT_PATH = "/dokument/hent";
@@ -94,6 +99,7 @@ public class ManuellJournalføringRestTjeneste {
     @Operation(description = "Henter alle åpne journalføringsoppgaver for tema FOR og for saksbehandlers tilhørende enhet.", tags = "Manuell journalføring", responses = {@ApiResponse(responseCode = "500", description = "Feil i request", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = FeilDto.class))),})
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK)
     public List<OppgaveDto> hentÅpneOppgaverForSaksbehandler(@TilpassetAbacAttributt(supplierClass = EmptyAbacDataSupplier.class) @QueryParam("ident") @NotNull @Valid SaksbehandlerIdentDto saksbehandlerIdentDto) {
+        LOG.info("FPFORDEL RESTJOURNALFØRING: Henter oppgaver");
         //Midlertidig for å kunne verifisere i produksjon - fjernes når verifisert ok
         if (ENV.isProd() && ("J116396".equals(KontekstHolder.getKontekst().getUid()) || "W119202".equals(KontekstHolder.getKontekst().getUid()))) {
             return oppgaver.finnÅpneOppgaverAvType(Oppgavetype.JOURNALFØRING, null, null , LIMIT)
@@ -130,6 +136,7 @@ public class ManuellJournalføringRestTjeneste {
     @Operation(description = "Henter detaljer for en gitt jornalpostId som er relevante for å kunne ferdigstille journalføring på en fagsak.", tags = "Manuell journalføring", responses = {@ApiResponse(responseCode = "500", description = "Feil i request", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = FeilDto.class))),})
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK)
     public JournalpostDetaljerDto hentJournalpostDetaljer(@TilpassetAbacAttributt(supplierClass = EmptyAbacDataSupplier.class) @QueryParam("journalpostId") @NotNull @Valid JournalpostIdDto journalpostId) {
+        LOG.info("FPFORDEL RESTJOURNALFØRING: Henter journalpostdetaljer");
         try {
             return Optional.ofNullable(arkiv.hentArkivJournalpost(journalpostId.getJournalpostId()))
                 .map(this::mapTilJournalpostDetaljerDto)
@@ -163,7 +170,7 @@ public class ManuellJournalføringRestTjeneste {
         }
     }
 
-    private static Set<JournalpostDetaljerDto.DokumentDto> mapDokumenter(String journalpostId, List<DokumentInfo> dokumenter) {
+        private static Set<JournalpostDetaljerDto.DokumentDto> mapDokumenter(String journalpostId, List<DokumentInfo> dokumenter) {
         return dokumenter.stream()
             .map(dok -> new JournalpostDetaljerDto.DokumentDto(dok.dokumentInfoId(), dok.tittel(),
                 String.format("%s?journalpostId=%s&dokumentId=%s", FULL_HENT_DOKUMENT_PATH, journalpostId, dok.dokumentInfoId())))

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/OppdaterJournalpostMedTittelRequest.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/OppdaterJournalpostMedTittelRequest.java
@@ -1,0 +1,12 @@
+package no.nav.foreldrepenger.fordel.web.app.rest.journalføring;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import java.util.List;
+
+public record OppdaterJournalpostMedTittelRequest(@NotNull @Pattern(regexp = "^(-?[1-9]|[a-z0])[a-z0-9_:-]*$", message = "journalpostId ${validatedValue} har ikke gyldig verdi (pattern '{regexp}')") String journalpostId,
+                                                  @NotNull List<OppdaterJournalpostMedTittelRequest.OppdaterDokumentRequest> dokumenter) {
+    public record OppdaterDokumentRequest(@NotNull DokumentIdDto dokumentIdDto, @NotNull String tittel) {
+    }
+}

--- a/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringRestTjenesteTest.java
@@ -1,64 +1,24 @@
 package no.nav.foreldrepenger.fordel.web.app.rest.journalføring;
 
 import static no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema.ENGANGSSTØNAD;
-import static no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema.ENGANGSSTØNAD_FØDSEL;
-import static no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema.FORELDREPENGER;
-import static no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema.FORELDREPENGER_ADOPSJON;
-import static no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema.FORELDREPENGER_FØDSEL;
-import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.ETTERSENDT_KLAGE;
-import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.FORELDREPENGER_ENDRING_SØKNAD;
-import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.INNTEKTSMELDING;
-import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.KLAGE_DOKUMENT;
-import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.SØKNAD_ENGANGSSTØNAD_FØDSEL;
-import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.SØKNAD_FORELDREPENGER_ADOPSJON;
-import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.SØKNAD_FORELDREPENGER_FØDSEL;
-import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.SØKNAD_SVANGERSKAPSPENGER;
-import static no.nav.foreldrepenger.fordel.kodeverdi.Journalposttype.INNGÅENDE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Objects;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.TimeZone;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema;
-import no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId;
-import no.nav.foreldrepenger.fordel.kodeverdi.Journalstatus;
 import no.nav.foreldrepenger.kontrakter.fordel.FagsakInfomasjonDto;
-import no.nav.foreldrepenger.kontrakter.fordel.SaksnummerDto;
-import no.nav.foreldrepenger.mottak.domene.dokument.DokumentRepository;
-import no.nav.foreldrepenger.mottak.domene.oppgavebehandling.FerdigstillOppgaveTask;
-import no.nav.foreldrepenger.mottak.journal.ArkivJournalpost;
-import no.nav.foreldrepenger.mottak.journal.ArkivTjeneste;
 import no.nav.foreldrepenger.mottak.klient.Fagsak;
-import no.nav.foreldrepenger.mottak.person.PersonInformasjon;
-import no.nav.foreldrepenger.mottak.tjeneste.VLKlargjører;
-import no.nav.vedtak.exception.FunksjonellException;
 import no.nav.vedtak.exception.TekniskException;
-import no.nav.vedtak.felles.integrasjon.oppgave.v1.Oppgaver;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
-import no.nav.vedtak.felles.prosesstask.api.TaskType;
 
 @ExtendWith(MockitoExtension.class)
 class FerdigstillJournalføringRestTjenesteTest {
@@ -73,21 +33,12 @@ class FerdigstillJournalføringRestTjenesteTest {
         TimeZone.setDefault(TimeZone.getTimeZone("Europe/Oslo"));
     }
 
-    private FerdigstillJournalføringRestTjeneste behandleDokument;
-    @Mock
-    private ArkivTjeneste arkiv;
-    @Mock
-    private VLKlargjører klargjør;
+    private FerdigstillJournalføringRestTjeneste behandleJournalpost;
     @Mock
     private Fagsak fagsak;
     @Mock
-    private PersonInformasjon aktør;
-    @Mock
-    private ArkivJournalpost journalpost;
-    @Mock
-    private Oppgaver oppgaver;
-    @Mock
-    private ProsessTaskTjeneste taskTjeneste;
+    FerdigstillJournalføringTjeneste journalføringTjeneste;
+
 
     private static FerdigstillJournalføringRestTjeneste.FerdigstillRequest req(String enhetid, String journalpostId, String sakId) {
         return new FerdigstillJournalføringRestTjeneste.FerdigstillRequest(journalpostId, enhetid, sakId, OPPGAVE_ID,null);
@@ -96,18 +47,16 @@ class FerdigstillJournalføringRestTjenesteTest {
     @BeforeEach
     public void setUp() {
 
-        lenient().when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.<SaksnummerDto>any()))
+        lenient().when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any()))
             .thenReturn(Optional.of(new FagsakInfomasjonDto(AKTØR_ID, ENGANGSSTØNAD.getOffisiellKode())));
-        lenient().when(journalpost.getJournalposttype()).thenReturn(INNGÅENDE);
-        lenient().when(arkiv.hentArkivJournalpost(JOURNALPOST_ID)).thenReturn(journalpost);
 
-        behandleDokument = new FerdigstillJournalføringRestTjeneste(klargjør, fagsak, aktør, arkiv, oppgaver, taskTjeneste, mock(DokumentRepository.class));
+        behandleJournalpost = new FerdigstillJournalføringRestTjeneste(journalføringTjeneste);
     }
 
     @Test
     void skalValiderePåkrevdInput_enhetId() {
         var req = req(null, JOURNALPOST_ID, SAKSNUMMER);
-        Exception ex = assertThrows(TekniskException.class, () -> behandleDokument.oppdaterOgFerdigstillJournalfoering(req));
+        Exception ex = assertThrows(TekniskException.class, () -> behandleJournalpost.oppdaterOgFerdigstillJournalfoering(req));
 
         assertThat(ex.getMessage()).contains("Ugyldig input: EnhetId");
     }
@@ -115,229 +64,22 @@ class FerdigstillJournalføringRestTjenesteTest {
     @Test
     void skalValiderePåkrevdInput_journalpostId() {
         var req = req(ENHETID, null, SAKSNUMMER);
-        Exception ex = assertThrows(TekniskException.class, () -> behandleDokument.oppdaterOgFerdigstillJournalfoering(req));
+        Exception ex = assertThrows(TekniskException.class, () -> behandleJournalpost.oppdaterOgFerdigstillJournalfoering(req));
         assertThat(ex.getMessage()).contains("Ugyldig input: JournalpostId");
     }
 
     @Test
     void skalValiderePåkrevdInput_opprettSakDto() {
         var req = req(ENHETID, JOURNALPOST_ID, null);
-        Exception ex = assertThrows(TekniskException.class, () -> behandleDokument.oppdaterOgFerdigstillJournalfoering(req));
+        Exception ex = assertThrows(TekniskException.class, () -> behandleJournalpost.oppdaterOgFerdigstillJournalfoering(req));
         assertThat(ex.getMessage()).contains("OpprettSakDto kan ikke være null ved opprettelse av en sak.");
     }
 
     @Test
-    void skalValidereAtFagsakFinnes() {
-        when(fagsak.finnFagsakInfomasjon(any())).thenReturn(Optional.empty());
+    void oppdatereJounralpost_skalKasteExceptionNårIngenDokumentÅOppdatere() {
+        var request = new OppdaterJournalpostMedTittelRequest(JOURNALPOST_ID, Collections.emptyList());
+        Exception ex = assertThrows(TekniskException.class, () -> behandleJournalpost.oppdaterJournalpost(request));
 
-        var req = req(ENHETID, JOURNALPOST_ID, SAKSNUMMER);
-        Exception ex = assertThrows(FunksjonellException.class, () -> behandleDokument.oppdaterOgFerdigstillJournalfoering(req));
-
-        assertThat(ex.getMessage()).contains("Kan ikke journalføre på saksnummer");
-
-    }
-
-    @Test
-    void skalIkkeJournalføreKlagerPåSakUtenBehandling() {
-
-        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.<SaksnummerDto>any())).thenReturn(
-            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, BehandlingTema.UDEFINERT.getOffisiellKode())));
-
-        when(journalpost.getHovedtype()).thenReturn(KLAGE_DOKUMENT);
-        var req = req(ENHETID, JOURNALPOST_ID, SAKSNUMMER);
-        assertThrows(FunksjonellException.class, () -> behandleDokument.oppdaterOgFerdigstillJournalfoering(req));
-    }
-
-    @Test
-    void skalKunneJournalføreKlagerPåSakMedBehandling() {
-
-        lenient().when(journalpost.getHovedtype()).thenReturn(KLAGE_DOKUMENT);
-        lenient().when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
-        lenient().doThrow(new IllegalArgumentException("FEIL")).when(oppgaver).ferdigstillOppgave(anyString());
-
-        behandleDokument.oppdaterOgFerdigstillJournalfoering(req(ENHETID, JOURNALPOST_ID, SAKSNUMMER));
-        verify(oppgaver).ferdigstillOppgave(String.valueOf(OPPGAVE_ID));
-        var taskCaptor = ArgumentCaptor.forClass(ProsessTaskData.class);
-        verify(taskTjeneste).lagre(taskCaptor.capture());
-        var taskdata = taskCaptor.getValue();
-        assertThat(taskdata.getTaskType()).isEqualTo(TaskType.forProsessTask(FerdigstillOppgaveTask.class).value());
-        assertThat(taskdata.getPropertyValue(FerdigstillOppgaveTask.OPPGAVEID_KEY)).isEqualTo(String.valueOf(OPPGAVE_ID));
-    }
-
-    @Test
-    void skalIkkeJournalførePapirsøknadSakAnnenYtelse() {
-
-        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.<SaksnummerDto>any())).thenReturn(
-            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER_FØDSEL.getOffisiellKode())));
-
-        when(journalpost.getHovedtype()).thenReturn(SØKNAD_SVANGERSKAPSPENGER);
-        var req = req(ENHETID, JOURNALPOST_ID, SAKSNUMMER);
-        assertThrows(FunksjonellException.class, () -> behandleDokument.oppdaterOgFerdigstillJournalfoering(req));
-    }
-
-    @Test
-    void skalKjøreHeltIgjennomNaarJournaltilstandIkkeErEndelig() throws Exception {
-        when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
-        when(journalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
-        when(journalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
-        when(journalpost.getHovedtype()).thenReturn(SØKNAD_ENGANGSSTØNAD_FØDSEL);
-
-        behandleDokument.oppdaterOgFerdigstillJournalfoering(req(ENHETID, JOURNALPOST_ID, SAKSNUMMER));
-
-        verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
-        verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
-        verify(klargjør).klargjør(any(), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(), eq(ENGANGSSTØNAD_FØDSEL), any(), any(), any(), any());
-    }
-
-    @Test
-    void skalTillateJournalførinAvInntektsmeldingForeldrepender() throws Exception {
-        when(journalpost.getHovedtype()).thenReturn(DokumentTypeId.INNTEKTSMELDING);
-        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.<SaksnummerDto>any())).thenReturn(
-            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER_FØDSEL.getOffisiellKode())));
-
-        when(journalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
-        when(journalpost.getStrukturertPayload()).thenReturn(readFile("testdata/inntektsmelding-foreldrepenger.xml"));
-        when(journalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
-        when(journalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
-        when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
-
-        behandleDokument.oppdaterOgFerdigstillJournalfoering(req(ENHETID, JOURNALPOST_ID, SAKSNUMMER));
-
-        verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
-        verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
-        verify(klargjør).klargjør(eq(readFile("testdata/inntektsmelding-foreldrepenger.xml")), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(),
-            eq(FORELDREPENGER_FØDSEL), any(), any(), any(), any());
-    }
-
-    @Test
-    void skalIkkeTillateJournalførinAvInntektsmeldingSvangerskapspenger() throws Exception {
-        when(journalpost.getHovedtype()).thenReturn(INNTEKTSMELDING);
-        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.<SaksnummerDto>any())).thenReturn(
-            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER_FØDSEL.getOffisiellKode())));
-
-        when(journalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
-        when(journalpost.getStrukturertPayload()).thenReturn(readFile("testdata/inntektsmelding-svangerskapspenger.xml"));
-
-        var req = req(ENHETID, JOURNALPOST_ID, SAKSNUMMER);
-        assertThrows(FunksjonellException.class, () -> behandleDokument.oppdaterOgFerdigstillJournalfoering(req));
-    }
-
-    @Test
-    void skalIkkeTillateJournalførinAvSøknadMedUttakFørGrense() throws Exception {
-        when(journalpost.getHovedtype()).thenReturn(SØKNAD_FORELDREPENGER_FØDSEL);
-        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.<SaksnummerDto>any())).thenReturn(
-            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER.getOffisiellKode())));
-
-        when(journalpost.getStrukturertPayload()).thenReturn(readFile("testdata/selvb-soeknad-forp-uttak-før-konfigverdi.xml"));
-        when(journalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
-        var req = req(ENHETID, JOURNALPOST_ID, SAKSNUMMER);
-        FunksjonellException ex = assertThrows(FunksjonellException.class, () -> behandleDokument.oppdaterOgFerdigstillJournalfoering(req));
-        assertThat(ex.getMessage()).contains("For tidlig");
-    }
-
-    @Test
-    void skalIkkeTillateJournalførinAvSøknadMedOmsorgFørGrense() throws Exception {
-        when(journalpost.getHovedtype()).thenReturn(SØKNAD_FORELDREPENGER_ADOPSJON);
-        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.<SaksnummerDto>any())).thenReturn(
-            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER.getOffisiellKode())));
-
-        when(journalpost.getStrukturertPayload()).thenReturn(readFile("testdata/fp-adopsjon-far.xml"));
-        when(journalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
-        var req = req(ENHETID, JOURNALPOST_ID, SAKSNUMMER);
-        var e = assertThrows(FunksjonellException.class, () -> behandleDokument.oppdaterOgFerdigstillJournalfoering(req));
-        assertThat(e.getMessage()).contains("For tidlig");
-    }
-
-    @Test
-    void skalTillateJournalførinAvSøknadMedUttakEtterGrense() throws Exception {
-        when(journalpost.getHovedtype()).thenReturn(SØKNAD_FORELDREPENGER_FØDSEL);
-        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.<SaksnummerDto>any())).thenReturn(
-            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER.getOffisiellKode())));
-
-        when(journalpost.getStrukturertPayload()).thenReturn(readFile("testdata/selvb-soeknad-forp.xml"));
-        when(journalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
-        when(journalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
-        when(journalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
-        when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
-
-        behandleDokument.oppdaterOgFerdigstillJournalfoering(req(ENHETID, JOURNALPOST_ID, SAKSNUMMER));
-
-        verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
-        verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
-        verify(klargjør).klargjør(eq(readFile("testdata/selvb-soeknad-forp.xml")), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(),
-            eq(FORELDREPENGER_FØDSEL), any(), any(), any(), any());
-    }
-
-    @Test
-    void skalIgnorereUkjentStrukturertData() throws Exception {
-        when(journalpost.getHovedtype()).thenReturn(ETTERSENDT_KLAGE);
-        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.<SaksnummerDto>any())).thenReturn(
-            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER.getOffisiellKode())));
-
-        when(journalpost.getStrukturertPayload()).thenReturn(readFile("testdata/metadata.json"));
-        when(journalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
-        when(journalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
-        when(journalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
-        when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
-
-        behandleDokument.oppdaterOgFerdigstillJournalfoering(req(ENHETID, JOURNALPOST_ID, SAKSNUMMER));
-
-        verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
-        verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
-        verify(klargjør).klargjør(eq(null), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(), eq(FORELDREPENGER), any(), any(), any(), any());
-    }
-
-    @Test
-    void skalTillateJournalførinAvSøknadMedOmsorgEtterGrense() throws Exception {
-        when(journalpost.getHovedtype()).thenReturn(SØKNAD_FORELDREPENGER_ADOPSJON);
-        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.<SaksnummerDto>any())).thenReturn(
-            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER.getOffisiellKode())));
-
-        when(journalpost.getStrukturertPayload()).thenReturn(readFile("testdata/fp-adopsjon-mor.xml"));
-        when(journalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
-        when(journalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
-        when(journalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
-        when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
-
-        behandleDokument.oppdaterOgFerdigstillJournalfoering(req(ENHETID, JOURNALPOST_ID, SAKSNUMMER));
-
-        verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
-        verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
-        verify(klargjør).klargjør(eq(readFile("testdata/fp-adopsjon-mor.xml")), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(),
-            eq(FORELDREPENGER_ADOPSJON), any(), any(), any(), any());
-    }
-
-    @Test
-    void skalTillateJournalførinAvEndringsSøknadMedAnnetSaksnummer() throws Exception {
-        when(journalpost.getHovedtype()).thenReturn(FORELDREPENGER_ENDRING_SØKNAD);
-        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.<SaksnummerDto>any())).thenReturn(
-            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER.getOffisiellKode())));
-
-        when(journalpost.getStrukturertPayload()).thenReturn(readFile("testdata/selvb-soeknad-endring.xml"));
-        when(journalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
-        when(journalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
-        when(journalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
-        when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
-
-        behandleDokument.oppdaterOgFerdigstillJournalfoering(req(ENHETID, JOURNALPOST_ID, SAKSNUMMER));
-
-        verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
-        verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
-        verify(klargjør).klargjør(eq(readFile("testdata/selvb-soeknad-endring.xml")), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(),
-            eq(FORELDREPENGER), any(), any(), any(), any());
-    }
-
-    @Test
-    void skalKjøreHeltIgjennomNaarJournaltilstandErEndelig() throws Exception {
-        when(journalpost.getTilstand()).thenReturn(Journalstatus.JOURNALFOERT);
-        when(journalpost.getHovedtype()).thenReturn(SØKNAD_ENGANGSSTØNAD_FØDSEL);
-        behandleDokument.oppdaterOgFerdigstillJournalfoering(req(ENHETID, JOURNALPOST_ID, SAKSNUMMER));
-
-        verify(klargjør).klargjør(any(), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(), eq(ENGANGSSTØNAD_FØDSEL), any(), any(), any(), any());
-    }
-
-    String readFile(String filename) throws URISyntaxException, IOException {
-        Path path = Paths.get(Objects.requireNonNull(getClass().getClassLoader().getResource(filename)).toURI());
-        return Files.readString(path);
+        assertThat(ex.getMessage()).contains("FpFordel: Ingen dokumenter å oppdatere for journalpostId");
     }
 }

--- a/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjenesteTest.java
@@ -1,0 +1,370 @@
+package no.nav.foreldrepenger.fordel.web.app.rest.journalføring;
+
+
+import static no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema.ENGANGSSTØNAD;
+import static no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema.ENGANGSSTØNAD_FØDSEL;
+import static no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema.FORELDREPENGER;
+import static no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema.FORELDREPENGER_ADOPSJON;
+import static no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema.FORELDREPENGER_FØDSEL;
+import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.DOK_INNLEGGELSE;
+import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.ETTERSENDT_KLAGE;
+import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.FORELDREPENGER_ENDRING_SØKNAD;
+import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.INNTEKTSMELDING;
+import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.KLAGE_DOKUMENT;
+import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.SØKNAD_ENGANGSSTØNAD_FØDSEL;
+import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.SØKNAD_FORELDREPENGER_ADOPSJON;
+import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.SØKNAD_FORELDREPENGER_FØDSEL;
+import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.SØKNAD_SVANGERSKAPSPENGER;
+import static no.nav.foreldrepenger.fordel.kodeverdi.Journalposttype.INNGÅENDE;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema;
+import no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId;
+import no.nav.foreldrepenger.fordel.kodeverdi.Journalstatus;
+import no.nav.foreldrepenger.kontrakter.fordel.FagsakInfomasjonDto;
+import no.nav.foreldrepenger.mottak.domene.dokument.DokumentRepository;
+import no.nav.foreldrepenger.mottak.domene.oppgavebehandling.FerdigstillOppgaveTask;
+import no.nav.foreldrepenger.mottak.journal.ArkivJournalpost;
+import no.nav.foreldrepenger.mottak.journal.ArkivTjeneste;
+import no.nav.foreldrepenger.mottak.journal.saf.DokumentInfo;
+import no.nav.foreldrepenger.mottak.journal.saf.Journalpost;
+import no.nav.foreldrepenger.mottak.klient.Fagsak;
+import no.nav.foreldrepenger.mottak.klient.FagsakYtelseTypeDto;
+import no.nav.foreldrepenger.mottak.person.PersonInformasjon;
+import no.nav.foreldrepenger.mottak.tjeneste.VLKlargjører;
+import no.nav.foreldrepenger.typer.AktørId;
+import no.nav.foreldrepenger.typer.JournalpostId;
+import no.nav.vedtak.exception.FunksjonellException;
+import no.nav.vedtak.felles.integrasjon.oppgave.v1.Oppgaver;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+import no.nav.vedtak.felles.prosesstask.api.TaskType;
+
+@ExtendWith(MockitoExtension.class)
+class FerdigstillJournalføringTjenesteTest {
+    private static final JournalpostId journalpostId = new JournalpostId("123");
+    private static final String JOURNALPOST_ID = "123";
+    private static final String ENHETID = "4567";
+    private static final String SAKSNUMMER = "789";
+    private static final String OPPGAVE_ID = "123456L";
+    private static final String AKTØR_ID = "9000000000009";
+    private static final AktørId aktørId = new AktørId("9000000000009");
+    private static final FagsakYtelseTypeDto ytelseType = FagsakYtelseTypeDto.FORELDREPENGER;
+    @Mock
+    private VLKlargjører klargjører;
+    @Mock
+    private Fagsak fagsak;
+    @Mock
+    private PersonInformasjon pdl;
+    @Mock
+    private Oppgaver oppgaver;
+    @Mock
+    private ProsessTaskTjeneste taskTjeneste;
+    @Mock
+    private ArkivTjeneste arkiv;
+    @Mock
+    private ArkivJournalpost arkivJournalpost;
+
+    private FerdigstillJournalføringTjeneste journalføringTjeneste;
+
+
+    @BeforeEach
+    public void setUp() {
+
+        lenient().when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any()))
+            .thenReturn(Optional.of(new FagsakInfomasjonDto(AKTØR_ID, ENGANGSSTØNAD.getOffisiellKode())));
+        lenient().when(arkivJournalpost.getJournalposttype()).thenReturn(INNGÅENDE);
+        lenient().when(arkiv.hentArkivJournalpost(JOURNALPOST_ID)).thenReturn(arkivJournalpost);
+
+        journalføringTjeneste = new FerdigstillJournalføringTjeneste(klargjører, fagsak, pdl, oppgaver, taskTjeneste, arkiv, mock(DokumentRepository.class));
+    }
+
+    @Test
+    void skalKunneJournalføreKlagerPåSakMedBehandling() {
+
+        lenient().when(arkivJournalpost.getHovedtype()).thenReturn(KLAGE_DOKUMENT);
+        lenient().when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
+        lenient().doThrow(new IllegalArgumentException("FEIL")).when(oppgaver).ferdigstillOppgave(anyString());
+
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, ytelseType, aktørId, OPPGAVE_ID);
+        verify(oppgaver).ferdigstillOppgave(OPPGAVE_ID);
+        var taskCaptor = ArgumentCaptor.forClass(ProsessTaskData.class);
+        verify(taskTjeneste).lagre(taskCaptor.capture());
+        var taskdata = taskCaptor.getValue();
+        assertThat(taskdata.getTaskType()).isEqualTo(TaskType.forProsessTask(FerdigstillOppgaveTask.class).value());
+        assertThat(taskdata.getPropertyValue(FerdigstillOppgaveTask.OPPGAVEID_KEY)).isEqualTo(OPPGAVE_ID);
+    }
+
+    @Test
+    void skalIkkeJournalføreKlagerPåSakUtenBehandling() {
+
+        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any())).thenReturn(
+            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, BehandlingTema.UDEFINERT.getOffisiellKode())));
+        when(arkivJournalpost.getHovedtype()).thenReturn(KLAGE_DOKUMENT);
+
+        assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, FagsakYtelseTypeDto.SVANGERSKAPSPENGER, aktørId, OPPGAVE_ID));
+    }
+
+    @Test
+    void skalIkkeJournalførePapirsøknadSakAnnenYtelse() {
+
+        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any())).thenReturn(
+            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER_FØDSEL.getOffisiellKode())));
+
+        when(arkivJournalpost.getHovedtype()).thenReturn(SØKNAD_SVANGERSKAPSPENGER);
+        assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, FagsakYtelseTypeDto.SVANGERSKAPSPENGER, aktørId, OPPGAVE_ID));
+    }
+
+    @Test
+    void skalValidereAtFagsakFinnes() {
+        when(fagsak.finnFagsakInfomasjon(any())).thenReturn(Optional.empty());
+
+        Exception ex = assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, FagsakYtelseTypeDto.SVANGERSKAPSPENGER, aktørId, OPPGAVE_ID));
+
+        assertThat(ex.getMessage()).contains("Kan ikke journalføre på saksnummer");
+    }
+
+    @Test
+    void skalKjøreHeltIgjennomNaarJournaltilstandIkkeErEndelig() {
+        when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
+        when(arkivJournalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
+        when(arkivJournalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
+        when(arkivJournalpost.getHovedtype()).thenReturn(SØKNAD_ENGANGSSTØNAD_FØDSEL);
+
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, ytelseType, aktørId, OPPGAVE_ID);
+
+        verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
+        verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
+        verify(klargjører).klargjør(any(), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(), eq(ENGANGSSTØNAD_FØDSEL), any(), any(), any(), any());
+    }
+
+    @Test
+    void skalTillateJournalførinAvInntektsmeldingForeldrepender() throws Exception {
+        when(arkivJournalpost.getHovedtype()).thenReturn(DokumentTypeId.INNTEKTSMELDING);
+        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any())).thenReturn(
+            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER_FØDSEL.getOffisiellKode())));
+
+        when(arkivJournalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
+        when(arkivJournalpost.getStrukturertPayload()).thenReturn(readFile("testdata/inntektsmelding-foreldrepenger.xml"));
+        when(arkivJournalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
+        when(arkivJournalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
+        when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
+
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, ytelseType, aktørId, OPPGAVE_ID);
+
+        verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
+        verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
+        verify(klargjører).klargjør(eq(readFile("testdata/inntektsmelding-foreldrepenger.xml")), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(),
+            eq(FORELDREPENGER_FØDSEL), any(), any(), any(), any());
+    }
+
+    @Test
+    void skalIkkeTillateJournalførinAvInntektsmeldingSvangerskapspenger() throws Exception {
+        when(arkivJournalpost.getHovedtype()).thenReturn(INNTEKTSMELDING);
+        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any())).thenReturn(
+            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER_FØDSEL.getOffisiellKode())));
+
+        when(arkivJournalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
+        when(arkivJournalpost.getStrukturertPayload()).thenReturn(readFile("testdata/inntektsmelding-svangerskapspenger.xml"));
+
+        assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, ytelseType, aktørId, OPPGAVE_ID));
+    }
+
+    @Test
+    void skalIkkeTillateJournalførinAvSøknadMedUttakFørGrense() throws Exception {
+        when(arkivJournalpost.getHovedtype()).thenReturn(SØKNAD_FORELDREPENGER_FØDSEL);
+        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any())).thenReturn(
+            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER.getOffisiellKode())));
+
+        when(arkivJournalpost.getStrukturertPayload()).thenReturn(readFile("testdata/selvb-soeknad-forp-uttak-før-konfigverdi.xml"));
+        when(arkivJournalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
+
+        FunksjonellException ex = assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, ytelseType, aktørId, OPPGAVE_ID));
+        assertThat(ex.getMessage()).contains("For tidlig");
+    }
+
+    @Test
+    void skalIkkeTillateJournalførinAvSøknadMedOmsorgFørGrense() throws Exception {
+        when(arkivJournalpost.getHovedtype()).thenReturn(SØKNAD_FORELDREPENGER_ADOPSJON);
+        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any())).thenReturn(
+            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER.getOffisiellKode())));
+
+        when(arkivJournalpost.getStrukturertPayload()).thenReturn(readFile("testdata/fp-adopsjon-far.xml"));
+        when(arkivJournalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
+
+        var e = assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, ytelseType, aktørId, OPPGAVE_ID));
+        assertThat(e.getMessage()).contains("For tidlig");
+    }
+
+    @Test
+    void skalTillateJournalførinAvSøknadMedUttakEtterGrense() throws Exception {
+        when(arkivJournalpost.getHovedtype()).thenReturn(SØKNAD_FORELDREPENGER_FØDSEL);
+        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any())).thenReturn(
+            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER.getOffisiellKode())));
+
+        when(arkivJournalpost.getStrukturertPayload()).thenReturn(readFile("testdata/selvb-soeknad-forp.xml"));
+        when(arkivJournalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
+        when(arkivJournalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
+        when(arkivJournalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
+        when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
+
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, ytelseType, aktørId, OPPGAVE_ID);
+
+        verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
+        verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
+        verify(klargjører).klargjør(eq(readFile("testdata/selvb-soeknad-forp.xml")), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(),
+            eq(FORELDREPENGER_FØDSEL), any(), any(), any(), any());
+    }
+
+    @Test
+    void skalIgnorereUkjentStrukturertData() throws Exception {
+        when(arkivJournalpost.getHovedtype()).thenReturn(ETTERSENDT_KLAGE);
+        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any())).thenReturn(
+            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER.getOffisiellKode())));
+
+        when(arkivJournalpost.getStrukturertPayload()).thenReturn(readFile("testdata/metadata.json"));
+        when(arkivJournalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
+        when(arkivJournalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
+        when(arkivJournalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
+        when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
+
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, ytelseType, aktørId, OPPGAVE_ID);
+
+        verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
+        verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
+        verify(klargjører).klargjør(eq(null), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(), eq(FORELDREPENGER), any(), any(), any(), any());
+    }
+
+    @Test
+    void skalTillateJournalførinAvSøknadMedOmsorgEtterGrense() throws Exception {
+        when(arkivJournalpost.getHovedtype()).thenReturn(SØKNAD_FORELDREPENGER_ADOPSJON);
+        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any())).thenReturn(
+            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER.getOffisiellKode())));
+
+        when(arkivJournalpost.getStrukturertPayload()).thenReturn(readFile("testdata/fp-adopsjon-mor.xml"));
+        when(arkivJournalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
+        when(arkivJournalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
+        when(arkivJournalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
+        when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
+
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, ytelseType, aktørId, OPPGAVE_ID);
+
+        verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
+        verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
+        verify(klargjører).klargjør(eq(readFile("testdata/fp-adopsjon-mor.xml")), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(),
+            eq(FORELDREPENGER_ADOPSJON), any(), any(), any(), any());
+    }
+
+    @Test
+    void skalTillateJournalførinAvEndringsSøknadMedAnnetSaksnummer() throws Exception {
+        when(arkivJournalpost.getHovedtype()).thenReturn(FORELDREPENGER_ENDRING_SØKNAD);
+        when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any())).thenReturn(
+            Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER.getOffisiellKode())));
+
+        when(arkivJournalpost.getStrukturertPayload()).thenReturn(readFile("testdata/selvb-soeknad-endring.xml"));
+        when(arkivJournalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
+        when(arkivJournalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
+        when(arkivJournalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
+        when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
+
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, ytelseType, aktørId, OPPGAVE_ID);
+
+        verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
+        verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
+        verify(klargjører).klargjør(eq(readFile("testdata/selvb-soeknad-endring.xml")), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(),
+            eq(FORELDREPENGER), any(), any(), any(), any());
+    }
+
+    @Test
+    void skalKjøreHeltIgjennomNaarJournaltilstandErEndelig() {
+        when(arkivJournalpost.getTilstand()).thenReturn(Journalstatus.JOURNALFOERT);
+        when(arkivJournalpost.getHovedtype()).thenReturn(SØKNAD_ENGANGSSTØNAD_FØDSEL);
+
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, ytelseType, aktørId, OPPGAVE_ID);
+
+        verify(klargjører).klargjør(any(), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(), eq(ENGANGSSTØNAD_FØDSEL), any(), any(), any(), any());
+    }
+
+    @Test
+    void oppdatereJounralpost_skalreturnereNyJournalpostTittel() {
+        var nyTittel = "Søknad om foreldrepenger ved fødsel";
+        var forrigeTittel = "Mor er innlagt i helseinstitusjon";
+        var dokumenterMedNyeTitler = (List.of(opprettDokument("1", nyTittel )));
+        when(arkivJournalpost.getHovedtype()).thenReturn(DOK_INNLEGGELSE);
+        when(arkivJournalpost.getOriginalJournalpost()).thenReturn(opprettJournalpost(forrigeTittel, List.of(new DokumentInfo("1", forrigeTittel, null, null, null))));
+
+        var journalpostTittel =  journalføringTjeneste.utledJournalpostTittelOgOppdater(dokumenterMedNyeTitler, journalpostId);
+
+        assertThat(journalpostTittel).isEqualTo(Optional.of(nyTittel));
+    }
+
+    @Test
+    void oppdatereJournalpost_skalIkkeReturnereNyJournalpostTittel() {
+        var nyTittel = "Mor er innlagt i helseinstitusjon";
+        var forrigeTittel = "Søknad om foreldrepenger ved fødsel";
+        var req = (List.of(opprettDokument("2", nyTittel )));
+        when(arkivJournalpost.getHovedtype()).thenReturn(SØKNAD_FORELDREPENGER_FØDSEL);
+        when(arkivJournalpost.getOriginalJournalpost()).thenReturn(opprettJournalpost(forrigeTittel, List.of(opprettDokumentInfo("3", forrigeTittel), opprettDokumentInfo("2", "Ukjent type dokument"), opprettDokumentInfo("1", "Klage/anke"))));
+
+        var journalpostTittel =  journalføringTjeneste.utledJournalpostTittelOgOppdater(req, journalpostId);
+
+        assertThat(journalpostTittel).isEmpty();
+    }
+
+    @Test
+    void oppdatereJournalpost_skalendreEksisterendeTittel() {
+        var nyTittel = "Mor er innlagt i helseinstitusjon";
+        var forrigeTittel = "Søknad om foreldrepenger ved fødsel";
+        var req = (List.of(opprettDokument("1", nyTittel )));
+        when(arkivJournalpost.getHovedtype()).thenReturn(SØKNAD_FORELDREPENGER_FØDSEL);
+        when(arkivJournalpost.getOriginalJournalpost()).thenReturn(opprettJournalpost(forrigeTittel, List.of(opprettDokumentInfo("1", forrigeTittel))));
+
+        var journalpostTittel =  journalføringTjeneste.utledJournalpostTittelOgOppdater(req, journalpostId);
+
+        assertThat(journalpostTittel).isEqualTo(Optional.of(DokumentTypeId.fraTermNavn(nyTittel).getTermNavn()));
+    }
+
+    private DokumentInfo opprettDokumentInfo(String id, String tittel) {
+        return new DokumentInfo(id, tittel, null, null, null);
+    }
+
+    private Journalpost opprettJournalpost(String tittel, List<DokumentInfo> dokumenter) {
+        return new Journalpost(JOURNALPOST_ID, "I", "MOTTATT", LocalDateTime.now(), tittel, null, null, null, null, null, null, null, null, null, dokumenter);
+    }
+
+    private FerdigstillJournalføringTjeneste.DokumenterMedNyTittel opprettDokument(String id, String tittel) {
+        return new FerdigstillJournalføringTjeneste.DokumenterMedNyTittel(id, tittel);
+    }
+
+    String readFile(String filename) throws URISyntaxException, IOException {
+        Path path = Paths.get(Objects.requireNonNull(getClass().getClassLoader().getResource(filename)).toURI());
+        return Files.readString(path);
+    }
+
+}


### PR DESCRIPTION
Lagt til et endepunkt for å oppdatere tittel på dokumenter tilhørende en journalpost. Dersom valg av nye titler fører til ny journalpost tittel returneres denne. Endepunktet tar i mot en journalpostId, og en liste av DokumentId og ny tittel.