### PR TITLE
Nasjonalisere Oslo og Tromsø

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/behandlendeenhet/EnhetsTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/behandlendeenhet/EnhetsTjeneste.java
@@ -27,7 +27,7 @@ import no.nav.vedtak.felles.integrasjon.oppgave.v1.Prioritet;
 @ApplicationScoped
 public class EnhetsTjeneste implements JournalføringsOppgave {
     private static final Logger LOG = LoggerFactory.getLogger(EnhetsTjeneste.class);
-    private static final Set<String> FLYTTET = Set.of("4806");
+    private static final Set<String> FLYTTET = Set.of("4806", "4833", "4849");
     private PersonInformasjon pdl;
     private Arbeidsfordeling norgKlient;
     private SkjermetPersonKlient skjermetPersonKlient;

--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,9 @@
 
         <tjenestespesifikasjon.version>1.2021.02.22-10.45-4201aaea72fb</tjenestespesifikasjon.version>
 
-        <felles.version>4.2.38</felles.version>
+        <felles.version>4.2.42</felles.version>
         <prosesstask.version>3.1.26</prosesstask.version>
-        <fp-kontrakter.version>6.2.17</fp-kontrakter.version>
+        <fp-kontrakter.version>6.2.19</fp-kontrakter.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Nye Journalføringsoppgaver Oslo og Tromsø legges til nasjonal enhet.
Merges og prodsettes ettermiddagen 28/4