### PR TITLE
TFP-5450 manuell journalføring

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/ManuellOpprettSakValidator.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/ManuellOpprettSakValidator.java
@@ -46,13 +46,17 @@ public class ManuellOpprettSakValidator {
         };
     }
 
-    public void validerKonsistensMedSak(JournalpostId journalpostId, FagsakYtelseTypeDto oppgittFagsakYtelseTypeDto, AktørId aktørId) {
+    public void validerKonsistensMedSak(JournalpostId journalpostId, FagsakYtelseTypeDto oppgittFagsakYtelseTypeDto, AktørId aktørId,
+                                        DokumentTypeId nyDokumentTypeId) {
         requireNonNull(journalpostId, "Ugyldig input: JournalpostId kan ikke være null ved opprettelse av en sak.");
         requireNonNull(oppgittFagsakYtelseTypeDto, "Ugyldig input: YtelseType kan ikke være null ved opprettelse av en sak.");
         requireNonNull(aktørId, "Ugyldig input: AktørId kan ikke være null ved opprettelse av en sak.");
 
         var arkivJournalpost = arkivTjeneste.hentArkivJournalpost(journalpostId.getVerdi());
         var hovedDokumentType = arkivJournalpost.getHovedtype();
+        if (nyDokumentTypeId != null) {
+            hovedDokumentType = nyDokumentTypeId;
+        }
 
         FagsakYtelseTypeDto journalpostFagsakYtelseTypeDto = null;
 

--- a/domene/src/test/java/no/nav/foreldrepenger/journalføring/JournalpostValideringTjenesteTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/journalføring/JournalpostValideringTjenesteTest.java
@@ -54,7 +54,7 @@ class JournalpostValideringTjenesteTest {
     @Test
     @DisplayName("Exception om oppgitt YtelseType er null.")
     void kast_exception_om_ytelseType_ikke_finnes() {
-        var exception = assertThrows(NullPointerException.class, () -> tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, null, AKTØR_ID));
+        var exception = assertThrows(NullPointerException.class, () -> tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, null, AKTØR_ID, null));
 
         var expectedMessage = "Ugyldig input: YtelseType kan ikke være null ved opprettelse av en sak";
         var actualMessage = exception.getMessage();
@@ -66,7 +66,8 @@ class JournalpostValideringTjenesteTest {
     @Test
     @DisplayName("Exception om oppgitt JournalpostId er null.")
     void kast_exception_om_journalpostId_ikke_finnes() {
-        var exception = assertThrows(NullPointerException.class, () -> tjeneste.validerKonsistensMedSak(null, FagsakYtelseTypeDto.SVANGERSKAPSPENGER, AKTØR_ID));
+        var exception = assertThrows(NullPointerException.class, () -> tjeneste.validerKonsistensMedSak(null, FagsakYtelseTypeDto.SVANGERSKAPSPENGER, AKTØR_ID,
+            null));
 
         var expectedMessage = "Ugyldig input: JournalpostId kan ikke være null ved opprettelse av en sak";
         var actualMessage = exception.getMessage();
@@ -77,7 +78,8 @@ class JournalpostValideringTjenesteTest {
     @Test
     @DisplayName("Exception om oppgitt AktørId er null.")
     void kast_exception_om_aktørId_ikke_finnes() {
-        var exception = assertThrows(NullPointerException.class, () -> tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, FagsakYtelseTypeDto.ENGANGSTØNAD, null));
+        var exception = assertThrows(NullPointerException.class, () -> tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, FagsakYtelseTypeDto.ENGANGSTØNAD, null,
+            null));
 
         var expectedMessage = "Ugyldig input: AktørId kan ikke være null ved opprettelse av en sak";
         var actualMessage = exception.getMessage();
@@ -92,7 +94,7 @@ class JournalpostValideringTjenesteTest {
         when(arkivTjeneste.hentArkivJournalpost(anyString())).thenReturn(journalpost);
         when(journalpost.getHovedtype()).thenReturn(DokumentTypeId.SØKNAD_FORELDREPENGER_FØDSEL);
 
-        tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, FagsakYtelseTypeDto.FORELDREPENGER, AKTØR_ID);
+        tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, FagsakYtelseTypeDto.FORELDREPENGER, AKTØR_ID, null);
 
         verify(arkivTjeneste, times(1)).hentArkivJournalpost(anyString());
     }
@@ -106,7 +108,7 @@ class JournalpostValideringTjenesteTest {
 
         var offisiellKode = FagsakYtelseTypeDto.ENGANGSTØNAD;
 
-        var exception = assertThrows(FunksjonellException.class, () -> tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, offisiellKode, AKTØR_ID));
+        var exception = assertThrows(FunksjonellException.class, () -> tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, offisiellKode, AKTØR_ID, null));
 
         var expectedMessage = "FP-785359:Dokument og valgt ytelsetype i uoverenstemmelse";
         var actualMessage = exception.getMessage();
@@ -127,7 +129,7 @@ class JournalpostValideringTjenesteTest {
         when(journalpost.getStrukturertPayload()).thenReturn("ytelse>FORELDREPENGER<");
 
         var offisiellKode = FagsakYtelseTypeDto.SVANGERSKAPSPENGER;
-        var exception = assertThrows(FunksjonellException.class, () -> tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, offisiellKode, AKTØR_ID));
+        var exception = assertThrows(FunksjonellException.class, () -> tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, offisiellKode, AKTØR_ID, null));
 
         var expectedMessage = "FP-785359:Dokument og valgt ytelsetype i uoverenstemmelse";
         var actualMessage = exception.getMessage();
@@ -153,7 +155,7 @@ class JournalpostValideringTjenesteTest {
         when(fagsak.hentBrukersSaker(new AktørIdDto(AKTØR_ID.getId()))).thenReturn(brukersFagsaker);
 
         var offisiellKode = FagsakYtelseTypeDto.FORELDREPENGER;
-        var exception = assertThrows(TekniskException.class, () -> tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, offisiellKode, AKTØR_ID));
+        var exception = assertThrows(TekniskException.class, () -> tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, offisiellKode, AKTØR_ID, null));
 
         var expectedMessage = "FP-34238:Kan ikke journalføre FP inntektsmelding på en ny sak fordi det finnes en aktiv foreldrepenger sak allerede.";
         var actualMessage = exception.getMessage();
@@ -172,7 +174,7 @@ class JournalpostValideringTjenesteTest {
         when(journalpost.getStrukturertPayload()).thenReturn("ytelse>SVANGERSKAPSPENGER<");
 
         var offisiellKode = FagsakYtelseTypeDto.FORELDREPENGER;
-        var exception = assertThrows(FunksjonellException.class, () -> tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, offisiellKode, AKTØR_ID));
+        var exception = assertThrows(FunksjonellException.class, () -> tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, offisiellKode, AKTØR_ID, null));
 
         var expectedMessage = "FP-785359:Dokument og valgt ytelsetype i uoverenstemmelse";
         var actualMessage = exception.getMessage();
@@ -193,7 +195,7 @@ class JournalpostValideringTjenesteTest {
 
         var offisiellKode = FagsakYtelseTypeDto.FORELDREPENGER;
 
-        var exception = assertThrows(FunksjonellException.class, () -> tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, offisiellKode, AKTØR_ID));
+        var exception = assertThrows(FunksjonellException.class, () -> tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, offisiellKode, AKTØR_ID, null));
 
         var expectedMessage = "FP-785359:Dokument og valgt ytelsetype i uoverenstemmelse";
         var actualMessage = exception.getMessage();
@@ -203,6 +205,18 @@ class JournalpostValideringTjenesteTest {
 
         assertTrue(actualMessage.contains(expectedMessage));
         assertTrue(løsningsforslag.contains(expectedLøsningsforslag));
+    }
+
+    @Test
+    @DisplayName("OK om ny dokumentTypeId gjelder søknad")
+    void ok_hvis_nyDokumentTypeId_og_gjelder_søknad() {
+
+        when(arkivTjeneste.hentArkivJournalpost(anyString())).thenReturn(journalpost);
+        when(journalpost.getHovedtype()).thenReturn(DokumentTypeId.ANNET);
+
+        tjeneste.validerKonsistensMedSak(JOURNALPOST_ID, FagsakYtelseTypeDto.SVANGERSKAPSPENGER, AKTØR_ID, DokumentTypeId.SØKNAD_SVANGERSKAPSPENGER);
+
+        verify(arkivTjeneste, times(1)).hentArkivJournalpost(anyString());
     }
 
     private SakInfoDto opprettSakInfo(FagsakYtelseTypeDto fagSakYtelseTypeDto, FagsakStatusDto ytelseStatus) {

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjeneste.java
@@ -90,7 +90,8 @@ public class FerdigstillJournalføringTjeneste {
     }
 
     public void oppdaterJournalpostOgFerdigstill(String enhetId, String saksnummer, JournalpostId journalpostId, String oppgaveId,
-                                                 String nyJournalpostTittel, List<DokumenterMedNyTittel> dokumenterMedNyTittel) {
+                                                 String nyJournalpostTittel, List<DokumenterMedNyTittel> dokumenterMedNyTittel,
+                                                 DokumentTypeId nyDokumentTypeId) {
 
         final var journalpost = hentJournalpost(journalpostId.getVerdi());
         validerJournalposttype(journalpost.getJournalposttype());
@@ -104,8 +105,8 @@ public class FerdigstillJournalføringTjeneste {
 
         var dokumentTypeId = journalpost.getHovedtype();
         var oppdatereTitler = nyJournalpostTittel != null || !dokumenterMedNyTittel.isEmpty();
-        if (nyJournalpostTittel != null) {
-            dokumentTypeId = DokumentTypeId.fraTermNavn(nyJournalpostTittel);
+        if (nyDokumentTypeId != null) {
+            dokumentTypeId = nyDokumentTypeId;
         }
 
         final var behandlingTemaDok = ArkivUtil.behandlingTemaFraDokumentType(BehandlingTema.UDEFINERT, dokumentTypeId);
@@ -228,8 +229,9 @@ public class FerdigstillJournalføringTjeneste {
         }
     }
 
-    String opprettSak(JournalpostId journalpostId, FerdigstillJournalføringRestTjeneste.OpprettSak opprettSakInfo) {
-        new ManuellOpprettSakValidator(arkivTjeneste, fagsak).validerKonsistensMedSak(journalpostId, opprettSakInfo.ytelseType(), opprettSakInfo.aktørId());
+    String opprettSak(JournalpostId journalpostId, FerdigstillJournalføringRestTjeneste.OpprettSak opprettSakInfo, DokumentTypeId nyDokumentTypeId) {
+        new ManuellOpprettSakValidator(arkivTjeneste, fagsak).validerKonsistensMedSak(journalpostId, opprettSakInfo.ytelseType(), opprettSakInfo.aktørId(),
+            nyDokumentTypeId);
 
         return fagsak.opprettSak(new OpprettSakV2Dto(journalpostId.getVerdi(), mapYtelseTypeTilDto(opprettSakInfo.ytelseType()), opprettSakInfo.aktørId().getId())).getSaksnummer();
     }

--- a/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringRestTjenesteTest.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.TimeZone;
 
+import no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,10 +82,10 @@ class FerdigstillJournalføringRestTjenesteTest {
     void sakSkalOpprettesNårSaksnummerErNull() {
         var req = req(ENHETID, JOURNALPOST_ID, null, YtelseTypeDto.FORELDREPENGER, AKTØR_ID, null);
         var journalpostId = new JournalpostId(JOURNALPOST_ID);
-        when(journalføringTjeneste.opprettSak(journalpostId, new FerdigstillJournalføringRestTjeneste.OpprettSak(new AktørId(AKTØR_ID), FagsakYtelseTypeDto.FORELDREPENGER))).thenReturn(SAKSNUMMER);
+        when(journalføringTjeneste.opprettSak(journalpostId, new FerdigstillJournalføringRestTjeneste.OpprettSak(new AktørId(AKTØR_ID), FagsakYtelseTypeDto.FORELDREPENGER),null)).thenReturn(SAKSNUMMER);
 
         behandleJournalpost.oppdaterOgFerdigstillJournalfoering(req);
-        verify(journalføringTjeneste).oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID.toString(),null , Collections.emptyList() );
+        verify(journalføringTjeneste).oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID.toString(),null , Collections.emptyList(), null );
     }
 
     @Test
@@ -96,7 +98,8 @@ class FerdigstillJournalføringRestTjenesteTest {
         var journalpostId = new JournalpostId(JOURNALPOST_ID);
 
         behandleJournalpost.oppdaterOgFerdigstillJournalfoering(req);
-        verify(journalføringTjeneste).oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID.toString(), journalpostTittel, List.of(new FerdigstillJournalføringTjeneste.DokumenterMedNyTittel("1", tittel1), new FerdigstillJournalføringTjeneste.DokumenterMedNyTittel("2", tittel2)));
+        verify(journalføringTjeneste).oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID.toString(), journalpostTittel, List.of(new FerdigstillJournalføringTjeneste.DokumenterMedNyTittel("1", tittel1), new FerdigstillJournalføringTjeneste.DokumenterMedNyTittel("2", tittel2)),
+            DokumentTypeId.UDEFINERT);
     }
 
     @Test

--- a/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjenesteTest.java
@@ -115,7 +115,7 @@ class FerdigstillJournalføringTjenesteTest {
         lenient().when(arkiv.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
         lenient().doThrow(new IllegalArgumentException("FEIL")).when(oppgaver).ferdigstillOppgave(anyString());
 
-        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList());
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList(),null);
         verify(oppgaver).ferdigstillOppgave(OPPGAVE_ID);
         var taskCaptor = ArgumentCaptor.forClass(ProsessTaskData.class);
         verify(taskTjeneste).lagre(taskCaptor.capture());
@@ -131,7 +131,7 @@ class FerdigstillJournalføringTjenesteTest {
             Optional.of(new FagsakInfomasjonDto(AKTØR_ID, BehandlingTema.UDEFINERT.getOffisiellKode())));
         when(arkivJournalpost.getHovedtype()).thenReturn(KLAGE_DOKUMENT);
 
-        assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, tomDokumentListe));
+        assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, tomDokumentListe, null));
     }
 
     @Test
@@ -142,7 +142,7 @@ class FerdigstillJournalføringTjenesteTest {
 
         when(arkivJournalpost.getHovedtype()).thenReturn(SØKNAD_SVANGERSKAPSPENGER);
         assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null,
-            tomDokumentListe));
+            tomDokumentListe, null));
     }
 
     @Test
@@ -150,7 +150,7 @@ class FerdigstillJournalføringTjenesteTest {
         when(fagsak.finnFagsakInfomasjon(any())).thenReturn(Optional.empty());
 
         Exception ex = assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null ,
-            tomDokumentListe));
+            tomDokumentListe, null));
 
         assertThat(ex.getMessage()).contains("Kan ikke journalføre på saksnummer");
     }
@@ -161,7 +161,7 @@ class FerdigstillJournalføringTjenesteTest {
         when(arkivJournalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
         when(arkivJournalpost.getHovedtype()).thenReturn(SØKNAD_ENGANGSSTØNAD_FØDSEL);
 
-        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList());
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList(), null);
 
         verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
         verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
@@ -179,7 +179,7 @@ class FerdigstillJournalføringTjenesteTest {
         when(arkivJournalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
         when(arkivJournalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
 
-        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList());
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList(), null);
 
         verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
         verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
@@ -197,7 +197,7 @@ class FerdigstillJournalføringTjenesteTest {
         when(arkivJournalpost.getStrukturertPayload()).thenReturn(readFile("testdata/inntektsmelding-svangerskapspenger.xml"));
 
         assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null,
-            tomDokumentListe));
+            tomDokumentListe, null));
     }
 
     @Test
@@ -210,7 +210,7 @@ class FerdigstillJournalføringTjenesteTest {
         when(arkivJournalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
 
         FunksjonellException ex = assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null,
-            tomDokumentListe));
+            tomDokumentListe, null));
         assertThat(ex.getMessage()).contains("For tidlig");
     }
 
@@ -224,7 +224,7 @@ class FerdigstillJournalføringTjenesteTest {
         when(arkivJournalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
 
         var e = assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null,
-            tomDokumentListe));
+            tomDokumentListe, null));
         assertThat(e.getMessage()).contains("For tidlig");
     }
 
@@ -239,7 +239,7 @@ class FerdigstillJournalføringTjenesteTest {
         when(arkivJournalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
         when(arkivJournalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
 
-        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList());
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList(), null);
 
         verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
         verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
@@ -258,7 +258,7 @@ class FerdigstillJournalføringTjenesteTest {
         when(arkivJournalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
         when(arkivJournalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
 
-        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList());
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList(), null);
 
         verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
         verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
@@ -276,7 +276,7 @@ class FerdigstillJournalføringTjenesteTest {
         when(arkivJournalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
         when(arkivJournalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
 
-        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList());
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList(), null);
 
         verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
         verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
@@ -295,7 +295,7 @@ class FerdigstillJournalføringTjenesteTest {
         when(arkivJournalpost.getTilstand()).thenReturn(Journalstatus.MOTTATT);
         when(arkivJournalpost.getJournalpostId()).thenReturn(JOURNALPOST_ID);
 
-        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList());
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList(), null);
 
         verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
         verify(arkiv).ferdigstillJournalføring(JOURNALPOST_ID, ENHETID);
@@ -308,7 +308,7 @@ class FerdigstillJournalføringTjenesteTest {
         when(arkivJournalpost.getTilstand()).thenReturn(Journalstatus.JOURNALFOERT);
         when(arkivJournalpost.getHovedtype()).thenReturn(SØKNAD_ENGANGSSTØNAD_FØDSEL);
 
-        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList());
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, null, Collections.emptyList(),  null);
 
         verify(klargjører).klargjør(any(), eq(SAKSNUMMER), eq(JOURNALPOST_ID), any(), any(), eq(ENGANGSSTØNAD_FØDSEL), any(), any(), any(), any());
     }
@@ -318,6 +318,7 @@ class FerdigstillJournalføringTjenesteTest {
         var nyTittel = "Søknad om foreldrepenger ved fødsel";
         var forrigeTittel = "Mor er innlagt i helseinstitusjon";
         var dokumenterMedNyeTitler = (List.of(opprettDokument(nyTittel )));
+        var nyDokumentTypeId = DokumentTypeId.fraTermNavn(nyTittel);
 
         when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any())).thenReturn(
             Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER_FØDSEL.getOffisiellKode())));
@@ -328,7 +329,7 @@ class FerdigstillJournalføringTjenesteTest {
         when(arkivJournalpost.getKanal()).thenReturn(MottakKanal.SKAN_NETS.name());
         when(arkivJournalpost.getOriginalJournalpost()).thenReturn(opprettJournalpost(forrigeTittel, List.of(new DokumentInfo("1", forrigeTittel, "kode", null, null))));
 
-        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, nyTittel, dokumenterMedNyeTitler);
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, nyTittel, dokumenterMedNyeTitler, nyDokumentTypeId);
 
         verify(arkiv, times(1)).oppdaterJournalpostVedManuellJournalføring(JOURNALPOST_ID, nyTittel, List.of(new OppdaterJournalpostRequest.DokumentInfoOppdater("1", nyTittel, null)), arkivJournalpost, AKTØR_ID, FORELDREPENGER_FØDSEL);
         verify(arkiv).oppdaterMedSak(JOURNALPOST_ID, SAKSNUMMER, AKTØR_ID);
@@ -340,6 +341,7 @@ class FerdigstillJournalføringTjenesteTest {
     void verifisereAtFeilKastesNårJournalpostErFraSelvbetjening() {
         var nyTittel = "Mor er innlagt i helseinstitusjon";
         var dokumenterMedNyeTitler = (List.of(opprettDokument(nyTittel )));
+        var nyDokumentTypeId = DokumentTypeId.fraTermNavn(nyTittel);
 
         when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any())).thenReturn(
             Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER_FØDSEL.getOffisiellKode())));
@@ -350,7 +352,7 @@ class FerdigstillJournalføringTjenesteTest {
         when(arkivJournalpost.getKanal()).thenReturn(MottakKanal.SELVBETJENING.name());
 
 
-        var e = assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, nyTittel, dokumenterMedNyeTitler));
+        var e = assertThrows(FunksjonellException.class, () -> journalføringTjeneste.oppdaterJournalpostOgFerdigstill(ENHETID, SAKSNUMMER, journalpostId, OPPGAVE_ID, nyTittel, dokumenterMedNyeTitler, nyDokumentTypeId));
         assertThat(e.getMessage()).contains("Kan ikke endre tittel på journalpost med id 123 som kommer fra Selvbetjening eller Altinn");
     }
 


### PR DESCRIPTION
Endret opprettSak slik at vi validerer mot ny DokumentTypeId og ikke den som ligger på journalposten dersom tittel på journalpost er endret. Dette skal gjøre det mulig for saksbehandler å journalføre papirsøknader som ikke har fått rett Dokumenttype i skanning på ny sak i fpsak (gjelder spesielt svp).