### PR TITLE
Teamdokumenthandtering url oppdatering

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/journal/dokarkiv/DokArkivKlient.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/journal/dokarkiv/DokArkivKlient.java
@@ -7,7 +7,7 @@ import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
 import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
 
 @Dependent
-@RestClientConfig(tokenConfig = TokenFlow.STS_CC, endpointProperty = "dokarkiv.base.url", endpointDefault = "http://dokarkiv.default/rest/journalpostapi/v1/journalpost")
+@RestClientConfig(tokenConfig = TokenFlow.STS_CC, endpointProperty = "dokarkiv.base.url", endpointDefault = "http://dokarkiv.teamdokumenthandtering/rest/journalpostapi/v1/journalpost")
 public class DokArkivKlient extends AbstractDokArkivKlient {
 
     protected DokArkivKlient() {

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/sak/SakRestKlient.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/sak/SakRestKlient.java
@@ -6,7 +6,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.core.UriBuilder;
 
 @ApplicationScoped
-@RestClientConfig(tokenConfig = TokenFlow.STS_CC, endpointProperty = "sak.rs.url", endpointDefault = "http://sak.default/api/v1/saker")
+@RestClientConfig(tokenConfig = TokenFlow.STS_CC, endpointProperty = "sak.rs.url", endpointDefault = "http://sak.teamdokumenthandtering/api/v1/saker")
 public class SakRestKlient implements SakClient {
 
     private final RestClient sender;


### PR DESCRIPTION
I NAIS sitt Kubernetes miljø ble det innført overgang fra standard namespace "default" til team namespace "team". Denne endringen påvirket også URL-ene for Kubernetes-tjenesteoppdagelse. Det ble slutt på oppretting av ressurser i default namespace den 29. september 2021.

Tidligere var en vanlig NAIS tjenesteoppdagelses-URL i Kubernetes som følger: "http://app.default/". Her refererte "default" til standardnavneområdet der tjenesten var plassert. Men nå, med innføringen av teamnavneområder, har URL-en blitt endret til "http://app.team/". Dette betyr at "team" erstatter "default" i URL-en og representerer det tilhørende teamet eller prosjektet som tjenesten tilhører.

For å lette denne overgangen ble det manuelt opprettet service redirects i default namespacet.

Vi ser at appen deres har en referanse til en av teamdokumenthandtering sine redirect service adresser. Denne patchen tar ned risiko for at dette skal feile i produksjon ved misforståelser, opprydding eller annet i default namespace til NAIS clusteret.