### PR TITLE
Fix: Endring av journalpost tittel fører til endring av dokumentType

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/ManuellOpprettSakValidator.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/ManuellOpprettSakValidator.java
@@ -52,7 +52,7 @@ public class ManuellOpprettSakValidator {
 
         var arkivJournalpost = arkivTjeneste.hentArkivJournalpost(journalpostId.getVerdi());
         var hovedDokumentType = arkivJournalpost.getHovedtype();
-        if (nyDokumentTypeId != null) {
+        if (nyDokumentTypeId != null && !DokumentTypeId.UDEFINERT.equals(nyDokumentTypeId)) {
             hovedDokumentType = nyDokumentTypeId;
         }
 

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringRestTjeneste.java
@@ -96,7 +96,6 @@ public class FerdigstillJournalføringRestTjeneste {
             LOG.info("FPFORDEL RESTJOURNALFØRING:Ny journalposttittel er: {}, ny dokumentTypeId: {}", nyJournalpostTittel, nyDokumentTypeId);
         }
 
-        var oppgaveId = request.oppgaveId();
         var saksnummer = request.saksnummer() != null ? request.saksnummer() : null;
 
         if (saksnummer == null) {
@@ -105,7 +104,7 @@ public class FerdigstillJournalføringRestTjeneste {
 
         validerSaksnummer(saksnummer);
 
-        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(request.enhetId, saksnummer, journalpostId, oppgaveId.toString(), nyJournalpostTittel ,dokumenter, nyDokumentTypeId );
+        journalføringTjeneste.oppdaterJournalpostOgFerdigstill(request.enhetId, saksnummer, journalpostId, request.oppgaveId().toString(), nyJournalpostTittel ,dokumenter, nyDokumentTypeId );
 
         return new SaksnummerDto(saksnummer);
     }

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjeneste.java
@@ -106,7 +106,7 @@ public class FerdigstillJournalføringTjeneste {
 
         var dokumentTypeId = journalpost.getHovedtype();
         var oppdatereTitler = nyJournalpostTittel != null || !dokumenterMedNyTittel.isEmpty();
-        if (nyDokumentTypeId != null && !DokumentTypeId.UDEFINERT.equals(nyDokumentTypeId)) {
+        if (nyDokumentTypeId != null) {
             dokumentTypeId = nyDokumentTypeId;
         }
 

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjeneste.java
@@ -106,7 +106,7 @@ public class FerdigstillJournalføringTjeneste {
 
         var dokumentTypeId = journalpost.getHovedtype();
         var oppdatereTitler = nyJournalpostTittel != null || !dokumenterMedNyTittel.isEmpty();
-        if (nyDokumentTypeId != null) {
+        if (nyDokumentTypeId != null && !DokumentTypeId.UDEFINERT.equals(nyDokumentTypeId)) {
             dokumentTypeId = nyDokumentTypeId;
         }
 


### PR DESCRIPTION
Foreslår å bruke det opprinnelige DokumentTypeId om den nye blir null eller UDEFINERT.