### PR TITLE
Confluent 7.4 med utvidet VTP-mock-schemareg

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/hendelse/test/VtpKafkaAvroDeserializer.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/hendelse/test/VtpKafkaAvroDeserializer.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.mottak.hendelse.test;
 
 import org.apache.avro.Schema;
+import org.apache.kafka.common.header.Headers;
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
@@ -23,5 +24,11 @@ public class VtpKafkaAvroDeserializer extends KafkaAvroDeserializer {
     public Object deserialize(String topic, byte[] bytes) {
         this.schemaRegistry = getMockClient(JournalfoeringHendelseRecord.SCHEMA$);
         return super.deserialize(topic, bytes);
+    }
+
+    @Override
+    public Object deserialize(String topic, Headers headers, byte[] bytes) {
+        this.schemaRegistry = getMockClient(JournalfoeringHendelseRecord.SCHEMA$);
+        return super.deserialize(topic, headers, bytes);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-streams-avro-serde</artifactId>
-                <version>7.3.3</version>
+                <version>7.4.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Dette virket for fpabonnent, prøver samme her.