### PR TITLE
TFP-5595 backend-støtte for å flytte en lokal oppgave til Gosys

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/domene/JournalpostId.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/domene/JournalpostId.java
@@ -50,14 +50,7 @@ public class JournalpostId implements Serializable {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == this) {
-            return true;
-        }
-        if (obj == null || !getClass().equals(obj.getClass())) {
-            return false;
-        }
-        var other = (JournalpostId) obj;
-        return Objects.equals(journalpostId, other.journalpostId);
+        return obj instanceof JournalpostId other && getClass().equals(other.getClass()) && Objects.equals(journalpostId, other.journalpostId);
     }
 
     @Override

--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/Journalføringsoppgave.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/Journalføringsoppgave.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.journalføring.oppgave;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import no.nav.foreldrepenger.journalføring.domene.JournalpostId;
@@ -19,9 +20,15 @@ public interface Journalføringsoppgave {
 
     Oppgave hentOppgaveFor(JournalpostId journalpostId);
 
+    Optional<Oppgave> hentLokalOppgaveFor(JournalpostId journalpostId);
+
+    void ferdigstillLokalOppgaveFor(JournalpostId journalpostId);
+
     void reserverOppgaveFor(Oppgave oppgave, String saksbehandlerId);
 
     void avreserverOppgaveFor(Oppgave oppgave);
 
     List<Oppgave> finnÅpneOppgaverFor(Set<String> enhet);
+
+    void flyttLokalOppgaveTilGosys(JournalpostId journalpostId);
 }

--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/OppgaverTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/OppgaverTjeneste.java
@@ -224,7 +224,7 @@ class OppgaverTjeneste implements Journalføringsoppgave {
             .medBeskrivelse(oppgave.beskrivelse())
             .medTilordnetRessurs(oppgave.tilordnetRessurs())
             .medAktivDato(oppgave.aktivDato())
-            .medKilde(Oppgave.Kilde.GLOBAL)
+            .medKilde(Oppgave.Kilde.GOSYS)
             .build();
     }
 

--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/domene/NyOppgave.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/domene/NyOppgave.java
@@ -1,8 +1,10 @@
 package no.nav.foreldrepenger.journalføring.oppgave.domene;
 
+import no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema;
 import no.nav.foreldrepenger.journalføring.domene.JournalpostId;
+import no.nav.foreldrepenger.journalføring.oppgave.lager.BrukerId;
 
-public record NyOppgave(JournalpostId journalpostId, String enhetId, String aktørId, String saksref, String behandlingTema, String beskrivelse) {
+public record NyOppgave(JournalpostId journalpostId, String enhetId, BrukerId aktørId, String saksref, BehandlingTema behandlingTema, String beskrivelse) {
     public static NyOppgaveBuilder builder() {
         return new NyOppgaveBuilder();
     }

--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/domene/NyOppgaveBuilder.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/domene/NyOppgaveBuilder.java
@@ -1,13 +1,17 @@
 package no.nav.foreldrepenger.journalføring.oppgave.domene;
 
+import java.util.Optional;
+
+import no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema;
 import no.nav.foreldrepenger.journalføring.domene.JournalpostId;
+import no.nav.foreldrepenger.journalføring.oppgave.lager.BrukerId;
 
 public class NyOppgaveBuilder {
     private JournalpostId journalpostId;
     private String enhetId;
-    private String aktørId;
+    private BrukerId aktørId;
     private String saksref;
-    private String behandlingTema;
+    private BehandlingTema behandlingTema;
     private String beskrivelse;
 
     NyOppgaveBuilder() {
@@ -24,6 +28,11 @@ public class NyOppgaveBuilder {
     }
 
     public NyOppgaveBuilder medAktørId(String aktørId) {
+        this.aktørId = Optional.ofNullable(aktørId).map(BrukerId::new).orElse(null);
+        return this;
+    }
+
+    public NyOppgaveBuilder medAktørId(BrukerId aktørId) {
         this.aktørId = aktørId;
         return this;
     }
@@ -33,7 +42,7 @@ public class NyOppgaveBuilder {
         return this;
     }
 
-    public NyOppgaveBuilder medBehandlingTema(String behandlingTema) {
+    public NyOppgaveBuilder medBehandlingTema(BehandlingTema behandlingTema) {
         this.behandlingTema = behandlingTema;
         return this;
     }

--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/domene/Oppgave.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/domene/Oppgave.java
@@ -13,7 +13,10 @@ public record Oppgave(String id,
                       Oppgavestatus status,
                       String beskrivelse,
                       String tilordnetRessurs,
+                      Kilde kilde,
                       String kildeId) {
+
+    public enum Kilde { LOKAL, GLOBAL }
 
     public static OppgaveBuilder builder() {
         return new OppgaveBuilder();

--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/domene/Oppgave.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/domene/Oppgave.java
@@ -16,7 +16,9 @@ public record Oppgave(String id,
                       Kilde kilde,
                       String kildeId) {
 
-    public enum Kilde { LOKAL, GLOBAL }
+    public enum Kilde { LOKAL,
+        GOSYS
+    }
 
     public static OppgaveBuilder builder() {
         return new OppgaveBuilder();

--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/domene/OppgaveBuilder.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/domene/OppgaveBuilder.java
@@ -15,6 +15,7 @@ public class OppgaveBuilder {
     private Oppgavestatus status;
     private String beskrivelse;
     private String tilordnetRessurs;
+    private Oppgave.Kilde kilde;
     private String kildeId;
 
     public OppgaveBuilder medId(String id) {
@@ -67,9 +68,14 @@ public class OppgaveBuilder {
         return this;
     }
 
+    public OppgaveBuilder medKilde(Oppgave.Kilde kilde) {
+        this.kilde = kilde;
+        return this;
+    }
+
     public Oppgave build() {
         validate();
-        return new Oppgave(id, aktoerId, ytelseType, tildeltEnhetsnr, fristFerdigstillelse, aktivDato, status, beskrivelse, tilordnetRessurs, kildeId);
+        return new Oppgave(id, aktoerId, ytelseType, tildeltEnhetsnr, fristFerdigstillelse, aktivDato, status, beskrivelse, tilordnetRessurs, kilde, kildeId);
     }
 
     private void validate() {
@@ -79,5 +85,7 @@ public class OppgaveBuilder {
         Objects.requireNonNull(status, "status");
         Objects.requireNonNull(fristFerdigstillelse, "frist");
         Objects.requireNonNull(beskrivelse, "beskrivelse");
+        Objects.requireNonNull(kilde, "kilde");
+        Objects.requireNonNull(kildeId, "kildeId");
     }
 }

--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/lager/BrukerId.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/lager/BrukerId.java
@@ -52,6 +52,16 @@ public class BrukerId implements Serializable {
         return getClass().getSimpleName() + "<" + maskerAktørId() + ">";
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof BrukerId other && getClass().equals(other.getClass()) && Objects.equals(id, other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
     public static boolean erGyldigBrukerId(String aktørId) {
         return aktørId != null && VALID.matcher(aktørId).matches();
     }

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/oppgavebehandling/FlyttLokalOppgaveTilGosysTask.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/oppgavebehandling/FlyttLokalOppgaveTilGosysTask.java
@@ -1,0 +1,76 @@
+package no.nav.foreldrepenger.mottak.domene.oppgavebehandling;
+
+import static no.nav.foreldrepenger.mottak.felles.MottakMeldingDataWrapper.ARKIV_ID_KEY;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema;
+import no.nav.foreldrepenger.fordel.kodeverdi.Tema;
+import no.nav.foreldrepenger.journalføring.domene.JournalpostId;
+import no.nav.foreldrepenger.journalføring.oppgave.Journalføringsoppgave;
+import no.nav.foreldrepenger.journalføring.oppgave.domene.NyOppgave;
+import no.nav.foreldrepenger.journalføring.oppgave.lager.BrukerId;
+import no.nav.foreldrepenger.mottak.behandlendeenhet.EnhetsTjeneste;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+
+/**
+ * <p>
+ * ProsessTask som oppretter en oppgave i GSAK for manuell behandling av
+ * tilfeller som ikke kan håndteres automatisk av vedtaksløsningen.
+ * <p>
+ * </p>
+ */
+@Dependent
+@ProsessTask(value = "integrasjon.gsak.flyttOppgave", maxFailedRuns = 2)
+public class FlyttLokalOppgaveTilGosysTask implements ProsessTaskHandler {
+
+    public static final String BESKRIVELSE_KEY = "oppgave.beskrivelse";
+
+    private static final Logger LOG = LoggerFactory.getLogger(FlyttLokalOppgaveTilGosysTask.class);
+
+    private final Journalføringsoppgave oppgaverTjeneste;
+    private final EnhetsTjeneste enhetsTjeneste;
+
+    @Inject
+    public FlyttLokalOppgaveTilGosysTask(ProsessTaskTjeneste taskTjeneste, Journalføringsoppgave oppgaverTjeneste, EnhetsTjeneste enhetsTjeneste) {
+        this.oppgaverTjeneste = oppgaverTjeneste;
+        this.enhetsTjeneste = enhetsTjeneste;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        var journalpostId = JournalpostId.fra(prosessTaskData.getPropertyValue(ARKIV_ID_KEY));
+        var oppgave = oppgaverTjeneste.hentLokalOppgaveFor(journalpostId).orElse(null);
+        if (oppgave == null) {
+            return;
+        }
+
+        var behandlingTema = switch (oppgave.ytelseType()) {
+            case ES -> BehandlingTema.ENGANGSSTØNAD;
+            case FP -> BehandlingTema.FORELDREPENGER;
+            case SVP -> BehandlingTema.SVANGERSKAPSPENGER;
+        };
+        var enhet = enhetsTjeneste.hentFordelingEnhetId(Tema.FORELDRE_OG_SVANGERSKAPSPENGER, behandlingTema,
+            Optional.ofNullable(oppgave.tildeltEnhetsnr()), oppgave.aktoerId());
+
+        var nyOppgave = NyOppgave.builder()
+            .medJournalpostId(journalpostId)
+            .medEnhetId(enhet)
+            .medAktørId(new BrukerId(oppgave.aktoerId()))
+            .medBehandlingTema(behandlingTema)
+            .medBeskrivelse(oppgave.beskrivelse())
+            .build();
+
+        LOG.info("Oppretter en gosys oppgave for journalpost {} ", journalpostId.getVerdi());
+        oppgaverTjeneste.opprettGosysJournalføringsoppgaveFor(nyOppgave);
+        oppgaverTjeneste.ferdigstillLokalOppgaveFor(journalpostId);
+    }
+}

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/oppgavebehandling/OpprettGSakOppgaveTask.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/oppgavebehandling/OpprettGSakOppgaveTask.java
@@ -122,7 +122,7 @@ public class OpprettGSakOppgaveTask implements ProsessTaskHandler {
     private String opprettOppgave(ProsessTaskData prosessTaskData, BehandlingTema behandlingTema, DokumentTypeId dokumentTypeId) {
         var enhetInput = prosessTaskData.getPropertyValue(JOURNAL_ENHET);
         // Oppgave har ikke mapping for alle undertyper fødsel/adopsjon
-        var brukBT = BehandlingTema.forYtelseUtenFamilieHendelse(behandlingTema).getOffisiellKode();
+        var brukBT = BehandlingTema.forYtelseUtenFamilieHendelse(behandlingTema);
 
         var journalpostId = prosessTaskData.getPropertyValue(ARKIV_ID_KEY);
 

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/felles/MottakMeldingDataWrapper.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/felles/MottakMeldingDataWrapper.java
@@ -37,7 +37,6 @@ public class MottakMeldingDataWrapper {
     public static final String BARN_OMSORGSOVERTAKELSEDATO_KEY = "barn.omsorgsovertakelsedato";
     public static final String BARN_ANTALL_KEY = "barn.antall";
     public static final String STRUKTURERT_DOKUMENT = "strukturert.dokument";
-    public static final String RETRY_ENDELIG = "retry.endelig";
     public static final String FORSENDELSE_MOTTATT_TIDSPUNKT_KEY = "forsendelse.mottatt.tidspunkt";
     public static final String JOURNAL_ENHET = "journalforende.enhet";
     public static final String FORSENDELSE_ID_KEY = "forsendelse.id";

--- a/domene/src/test/java/no/nav/foreldrepenger/journalføring/oppgave/OppgaverTjenesteTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/journalføring/oppgave/OppgaverTjenesteTest.java
@@ -32,6 +32,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema;
 import no.nav.foreldrepenger.journalføring.domene.JournalpostId;
 import no.nav.foreldrepenger.journalføring.oppgave.domene.NyOppgave;
+import no.nav.foreldrepenger.journalføring.oppgave.lager.BrukerId;
+import no.nav.foreldrepenger.journalføring.oppgave.domene.NyOppgave;
 import no.nav.foreldrepenger.journalføring.oppgave.domene.OppgaveBuilder;
 import no.nav.foreldrepenger.journalføring.oppgave.lager.OppgaveEntitet;
 import no.nav.foreldrepenger.journalføring.oppgave.lager.OppgaveRepository;
@@ -43,6 +45,7 @@ import no.nav.vedtak.felles.integrasjon.oppgave.v1.Oppgavestatus;
 import no.nav.vedtak.felles.integrasjon.oppgave.v1.Oppgavetype;
 import no.nav.vedtak.felles.integrasjon.oppgave.v1.OpprettOppgave;
 import no.nav.vedtak.felles.integrasjon.oppgave.v1.Prioritet;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 @ExtendWith(MockitoExtension.class)
 class OppgaverTjenesteTest {
@@ -55,7 +58,7 @@ class OppgaverTjenesteTest {
 
     @BeforeEach
     void setUp() {
-        oppgaver = new OppgaverTjeneste(oppgaveRepository, oppgaveKlient);
+        oppgaver = new OppgaverTjeneste(oppgaveRepository, oppgaveKlient, mock(ProsessTaskTjeneste.class));
     }
 
     @Test
@@ -68,9 +71,9 @@ class OppgaverTjenesteTest {
         var id = oppgaver.opprettGosysJournalføringsoppgaveFor(NyOppgave.builder()
             .medJournalpostId(JournalpostId.fra("123456"))
             .medEnhetId("1234")
-            .medAktørId("1234567890123")
+            .medAktørId(new BrukerId("1234567890123"))
             .medSaksref("referanse")
-            .medBehandlingTema(BehandlingTema.SVANGERSKAPSPENGER.getOffisiellKode())
+            .medBehandlingTema(BehandlingTema.SVANGERSKAPSPENGER)
             .medBeskrivelse("Test beskrivelse")
             .build());
 
@@ -81,15 +84,15 @@ class OppgaverTjenesteTest {
 
     @Test
     void opprettJournalføringsOppgaveLokalt() {
-        oppgaver = new OppgaverTjeneste(oppgaveRepository, oppgaveKlient);
+        oppgaver = new OppgaverTjeneste(oppgaveRepository, oppgaveKlient, mock(ProsessTaskTjeneste.class));
         var expectedId = "11";
         when(oppgaveRepository.lagre(any(OppgaveEntitet.class))).thenReturn(expectedId);
 
         var id = oppgaver.opprettJournalføringsoppgaveFor(NyOppgave.builder().medJournalpostId(JournalpostId.fra("123456"))
             .medEnhetId("1234")
-            .medAktørId("1234567890123")
+            .medAktørId(new BrukerId("1234567890123"))
             .medSaksref("referanse")
-            .medBehandlingTema(BehandlingTema.FORELDREPENGER.getOffisiellKode())
+            .medBehandlingTema(BehandlingTema.FORELDREPENGER)
             .medBeskrivelse("Test beskrivelse")
             .build());
 

--- a/domene/src/test/java/no/nav/foreldrepenger/journalføring/oppgave/OppgaverTjenesteTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/journalføring/oppgave/OppgaverTjenesteTest.java
@@ -32,9 +32,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema;
 import no.nav.foreldrepenger.journalføring.domene.JournalpostId;
 import no.nav.foreldrepenger.journalføring.oppgave.domene.NyOppgave;
-import no.nav.foreldrepenger.journalføring.oppgave.lager.BrukerId;
-import no.nav.foreldrepenger.journalføring.oppgave.domene.NyOppgave;
 import no.nav.foreldrepenger.journalføring.oppgave.domene.OppgaveBuilder;
+import no.nav.foreldrepenger.journalføring.oppgave.lager.BrukerId;
 import no.nav.foreldrepenger.journalføring.oppgave.lager.OppgaveEntitet;
 import no.nav.foreldrepenger.journalføring.oppgave.lager.OppgaveRepository;
 import no.nav.foreldrepenger.journalføring.oppgave.lager.Status;
@@ -197,6 +196,7 @@ class OppgaverTjenesteTest {
         var journalpostId = "1234";
         var saksbehandler = "TestIdent";
         var oppgave = new OppgaveBuilder().medId(journalpostId).medKildeId(journalpostId)
+            .medKilde(no.nav.foreldrepenger.journalføring.oppgave.domene.Oppgave.Kilde.GOSYS)
             .medAktivDato(LocalDate.now()).medTildeltEnhetsnr("4867")
             .medStatus(no.nav.foreldrepenger.journalføring.oppgave.domene.Oppgavestatus.AAPNET)
             .medFristFerdigstillelse(LocalDate.now().plusDays(1))
@@ -215,6 +215,7 @@ class OppgaverTjenesteTest {
         var journalpostId = "1234";
         var saksbehandler = "TestIdent";
         var oppgave = new OppgaveBuilder().medId(journalpostId).medKildeId(journalpostId)
+            .medKilde(no.nav.foreldrepenger.journalføring.oppgave.domene.Oppgave.Kilde.LOKAL)
             .medAktivDato(LocalDate.now()).medTildeltEnhetsnr("4867")
             .medStatus(no.nav.foreldrepenger.journalføring.oppgave.domene.Oppgavestatus.AAPNET)
             .medFristFerdigstillelse(LocalDate.now().plusDays(1))
@@ -236,6 +237,7 @@ class OppgaverTjenesteTest {
     void avreserverOppgaveGosys() {
         var journalpostId = "1234";
         var oppgave = new OppgaveBuilder().medId(journalpostId).medKildeId(journalpostId)
+            .medKilde(no.nav.foreldrepenger.journalføring.oppgave.domene.Oppgave.Kilde.GOSYS)
             .medAktivDato(LocalDate.now()).medTildeltEnhetsnr("4867")
             .medStatus(no.nav.foreldrepenger.journalføring.oppgave.domene.Oppgavestatus.AAPNET)
             .medFristFerdigstillelse(LocalDate.now().plusDays(1))
@@ -253,6 +255,7 @@ class OppgaverTjenesteTest {
     void avreserverOppgaveLokalt() {
         var journalpostId = "1234";
         var oppgave = new OppgaveBuilder().medId(journalpostId).medKildeId(journalpostId)
+            .medKilde(no.nav.foreldrepenger.journalføring.oppgave.domene.Oppgave.Kilde.LOKAL)
             .medAktivDato(LocalDate.now()).medTildeltEnhetsnr("4867")
             .medStatus(no.nav.foreldrepenger.journalføring.oppgave.domene.Oppgavestatus.AAPNET)
             .medFristFerdigstillelse(LocalDate.now().plusDays(1))

--- a/domene/src/test/java/no/nav/foreldrepenger/mottak/domene/oppgavebehandling/OpprettGSakOppgaveTjenesteTaskTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/mottak/domene/oppgavebehandling/OpprettGSakOppgaveTjenesteTaskTest.java
@@ -139,7 +139,7 @@ class OpprettGSakOppgaveTjenesteTaskTest {
             .medEnhetId(enhet)
             .medAktørId(aktørId)
             .medSaksref(null)
-            .medBehandlingTema(behandlingTema.getOffisiellKode())
+            .medBehandlingTema(behandlingTema)
             .medBeskrivelse(beskrivelse)
             .build();
     }

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/ManuellJournalføringRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/ManuellJournalføringRestTjeneste.java
@@ -317,7 +317,7 @@ public class ManuellJournalføringRestTjeneste {
         }
         return switch (oppgave.kilde()) {
             case LOKAL -> OppgaveKilde.LOKAL;
-            case GLOBAL -> OppgaveKilde.GOSYS;
+            case GOSYS -> OppgaveKilde.GOSYS;
         };
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/ManuellJournalføringRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/ManuellJournalføringRestTjeneste.java
@@ -191,6 +191,21 @@ public class ManuellJournalføringRestTjeneste {
     }
 
     @POST
+    @Path("/oppgave/tilgosys")
+    @Produces(APPLICATION_JSON)
+    @Operation(description = "Flytter evt lokal oppgave til Gosys for å utføre avanserte funksjoner.", tags = "Manuell journalføring", responses = {@ApiResponse(responseCode = "500", description = "Feil i request", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = FeilDto.class))),})
+    @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.FAGSAK)
+    public Response flyttOppgaveTilGosys(@TilpassetAbacAttributt(supplierClass = EmptyAbacDataSupplier.class) @QueryParam("journalpostId") @NotNull @Valid JournalpostIdDto journalpostId) {
+        LOG.info("FPFORDEL TILGOSYS: Flytter journalpostId {} til Gosys", journalpostId.getJournalpostId());
+        try {
+            oppgaveTjeneste.flyttLokalOppgaveTilGosys(JournalpostId.fra(journalpostId.getJournalpostId()));
+            return Response.ok().build();
+        } catch (NoSuchElementException ex) {
+            throw new TekniskException("FORDEL-123", "Journalpost " + journalpostId.getJournalpostId() + " kunne ikke flyttes til Gosys.", ex);
+        }
+    }
+
+    @POST
     @Path("/oppgave/reserver")
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
@@ -280,26 +295,36 @@ public class ManuellJournalføringRestTjeneste {
     }
 
     private OppgaveDto lagOppgaveDto(Oppgave oppgave) {
-        return new OppgaveDto(Long.valueOf(oppgave.id()), oppgave.id(), oppgave.aktoerId(), hentPersonIdent(oppgave.aktoerId()).orElse(null),
-            mapYtelseType(oppgave.ytelseType()), oppgave.fristFerdigstillelse(), OppgavePrioritet.NORM, oppgave.beskrivelse(),
-            tekstFraBeskrivelse(oppgave.beskrivelse()), oppgave.aktivDato(), oppgave.tildeltEnhetsnr(), oppgave.tilordnetRessurs());
+        return new OppgaveDto(Long.valueOf(oppgave.id()), oppgave.id(), oppgave.aktoerId(), hentPersonIdent(oppgave).orElse(null),
+            mapYtelseType(oppgave), oppgave.fristFerdigstillelse(), OppgavePrioritet.NORM, oppgave.beskrivelse(),
+            tekstFraBeskrivelse(oppgave.beskrivelse()), oppgave.aktivDato(), oppgave.tildeltEnhetsnr(), oppgave.tilordnetRessurs(), mapKilde(oppgave));
     }
 
-    static YtelseTypeDto mapYtelseType(YtelseType ytelseType) {
-        if (null == ytelseType) {
+    static YtelseTypeDto mapYtelseType(Oppgave oppgave) {
+        if (oppgave == null || oppgave.ytelseType() == null) {
             return null;
         }
-        return switch (ytelseType) {
+        return switch (oppgave.ytelseType()) {
             case FP -> YtelseTypeDto.FORELDREPENGER;
             case SVP -> YtelseTypeDto.SVANGERSKAPSPENGER;
             case ES -> YtelseTypeDto.ENGANGSTØNAD;
         };
     }
 
+    static OppgaveKilde mapKilde(Oppgave oppgave) {
+        if (oppgave == null || oppgave.kilde() == null) {
+            return null;
+        }
+        return switch (oppgave.kilde()) {
+            case LOKAL -> OppgaveKilde.LOKAL;
+            case GLOBAL -> OppgaveKilde.GOSYS;
+        };
+    }
 
-    private Optional<String> hentPersonIdent(String aktørId) {
-        if (aktørId != null) {
-            return pdl.hentPersonIdentForAktørId(aktørId);
+
+    private Optional<String> hentPersonIdent(Oppgave oppgave) {
+        if (oppgave != null && oppgave.aktoerId() != null) {
+            return pdl.hentPersonIdentForAktørId(oppgave.aktoerId());
         }
         return Optional.empty();
     }
@@ -309,6 +334,8 @@ public class ManuellJournalføringRestTjeneste {
         NORM,
         LAV
     }
+
+    public enum OppgaveKilde { LOKAL, GOSYS }
 
     public record OppdaterBrukerDto(@NotNull String journalpostId, @NotNull String fødselsnummer) {
     }
@@ -328,7 +355,8 @@ public class ManuellJournalføringRestTjeneste {
                              String trimmetBeskrivelse,
                              @NotNull LocalDate opprettetDato,
                              String enhetId,
-                             String reservertAv) {
+                             String reservertAv,
+                             OppgaveKilde kilde) {
 
     }
 

--- a/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/ManuellJournalføringRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/ManuellJournalføringRestTjenesteTest.java
@@ -111,6 +111,7 @@ class ManuellJournalføringRestTjenesteTest {
         assertThat(oppgave.prioritet()).isEqualTo(ManuellJournalføringRestTjeneste.OppgavePrioritet.NORM);
         assertThat(oppgave.ytelseType()).isEqualTo(YtelseTypeDto.FORELDREPENGER);
         assertThat(oppgave.enhetId()).isEqualTo(tilhørendeEnhetDto.enhetsnummer());
+        assertThat(oppgave.kilde()).isEqualTo(ManuellJournalføringRestTjeneste.OppgaveKilde.GOSYS);
     }
 
     @Test
@@ -433,6 +434,7 @@ class ManuellJournalføringRestTjenesteTest {
             .medTilordnetRessurs(reservertAv)
             .medAktivDato(now)
             .medFristFerdigstillelse(now)
+            .medKilde(Oppgave.Kilde.GLOBAL)
             .build();
     }
 

--- a/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/ManuellJournalføringRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/ManuellJournalføringRestTjenesteTest.java
@@ -435,6 +435,7 @@ class ManuellJournalføringRestTjenesteTest {
             .medAktivDato(now)
             .medFristFerdigstillelse(now)
             .medKilde(Oppgave.Kilde.GOSYS)
+            .medKildeId(expectedId)
             .build();
     }
 

--- a/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/ManuellJournalføringRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/ManuellJournalføringRestTjenesteTest.java
@@ -434,7 +434,7 @@ class ManuellJournalføringRestTjenesteTest {
             .medTilordnetRessurs(reservertAv)
             .medAktivDato(now)
             .medFristFerdigstillelse(now)
-            .medKilde(Oppgave.Kilde.GLOBAL)
+            .medKilde(Oppgave.Kilde.GOSYS)
             .build();
     }
 


### PR DESCRIPTION
Oppgaver til frontend har et ekstra felt "kilde" som er LOKAL eller GOSYS. tenkt brukt til å enable "Flytt til Gosys"
Endepunkt for å flytte en lokal oppgave til Gosys - slik at man kan gjøre avanserte ting vi ikke vil støtte (bytt tema, ....)