### PR TITLE
Trenger en no-arg-ctor om ikke en Interface er brukt.

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/OppgaverTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/OppgaverTjeneste.java
@@ -36,7 +36,6 @@ import no.nav.foreldrepenger.mottak.behandlendeenhet.EnhetsTjeneste;
 import no.nav.foreldrepenger.mottak.behandlendeenhet.LosEnheterCachedTjeneste;
 import no.nav.foreldrepenger.mottak.klient.TilhørendeEnhetDto;
 import no.nav.foreldrepenger.mottak.person.PersonInformasjon;
-import no.nav.foreldrepenger.mottak.person.PersonTjeneste;
 import no.nav.vedtak.felles.integrasjon.oppgave.v1.Oppgaver;
 import no.nav.vedtak.felles.integrasjon.oppgave.v1.Oppgavetype;
 import no.nav.vedtak.felles.integrasjon.oppgave.v1.OpprettOppgave;
@@ -62,7 +61,7 @@ class OppgaverTjeneste implements Journalføringsoppgave {
 
     @Inject
     public OppgaverTjeneste(OppgaveRepository oppgaveRepository, Oppgaver oppgaveKlient, EnhetsTjeneste enhetsTjeneste,
-                            LosEnheterCachedTjeneste losEnheterCachedTjeneste, PersonTjeneste personTjeneste) {
+                            LosEnheterCachedTjeneste losEnheterCachedTjeneste, PersonInformasjon personTjeneste) {
         this.oppgaveRepository = oppgaveRepository;
         this.oppgaveKlient = oppgaveKlient;
         this.enhetsTjeneste = enhetsTjeneste;

--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/OppgaverTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/oppgave/OppgaverTjeneste.java
@@ -54,11 +54,6 @@ class OppgaverTjeneste implements Journalføringsoppgave {
     private LosEnheterCachedTjeneste losEnheterCachedTjeneste;
     private PersonInformasjon personTjeneste;
 
-
-    OppgaverTjeneste() {
-        // CDI
-    }
-
     @Inject
     public OppgaverTjeneste(OppgaveRepository oppgaveRepository, Oppgaver oppgaveKlient, EnhetsTjeneste enhetsTjeneste,
                             LosEnheterCachedTjeneste losEnheterCachedTjeneste, PersonInformasjon personTjeneste) {

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/behandlendeenhet/LosEnheterCachedTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/behandlendeenhet/LosEnheterCachedTjeneste.java
@@ -21,9 +21,13 @@ public class LosEnheterCachedTjeneste {
     private static final int DEFAULT_CACHE_SIZE = 200;
     private static final long DEFAULT_CACHE_TIMEOUT = TimeUnit.MILLISECONDS.convert(12, TimeUnit.HOURS);
 
-    private final LRUCache<String, List<TilhørendeEnhetDto>> enheterCache;
+    private LRUCache<String, List<TilhørendeEnhetDto>> enheterCache;
 
-    private final Los losKlient;
+    private Los losKlient;
+
+    LosEnheterCachedTjeneste() {
+        // CDI
+    }
 
     @Inject
     public LosEnheterCachedTjeneste(Los losKlient) {


### PR DESCRIPTION
Interessant WELD feature - om man kun bruker en Interface av en tjeneste så er det ikke nyttig at selve implementasjonen har en no-arg konstruktor definert. Se `PersonTjeneste` eller `OppgaverTjeneste`. Her brukes det `PersonInformasjon` og `Journalføringsoppgave` interfaces og da er np-arg ctor ikke nytt mens de andre tjenesten som ikke benytter et interface må definere en no-arg ctor til å virker korrekt.