### PR TITLE
Tidlig støtte for migrering postgres

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/dokument/DokumentRepository.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/dokument/DokumentRepository.java
@@ -113,6 +113,11 @@ public class DokumentRepository {
             .getResultList();
     }
 
+    public List<Journalpost> hentAlleJournalposter() {
+        return em.createQuery("from Journalpost", Journalpost.class)
+            .getResultList();
+    }
+
     public int slettJournalpostLokalEldreEnn(LocalDate dato) {
         return em.createQuery("delete from Journalpost where opprettetTidspunkt < :opprettet").setParameter("opprettet", dato.atStartOfDay()).executeUpdate();
     }

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/task/SlettGamleTasksBatchTask.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/task/SlettGamleTasksBatchTask.java
@@ -33,7 +33,7 @@ public class SlettGamleTasksBatchTask implements ProsessTaskHandler {
     public void doTask(ProsessTaskData prosessTaskData) {
         var slettetTask = prosessTaskTjeneste.slettÅrsgamleFerdige();
         LOG.info("Slettet {} tasks som er over ett år gamle.", slettetTask);
-        var slettetJournalpost = dokumentRepository.slettJournalpostLokalEldreEnn(LocalDate.now().minusYears(1));
-        LOG.info("Slettet {} journalposter som er over ett år gamle.", slettetJournalpost);
+        var slettetJournalpost = dokumentRepository.slettJournalpostLokalEldreEnn(LocalDate.now().minusMonths(4));
+        LOG.info("Slettet {} journalposter som er over 4 måneder gamle.", slettetJournalpost);
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/forvaltning/migrering/MigreringJournalpostDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/forvaltning/migrering/MigreringJournalpostDto.java
@@ -1,0 +1,16 @@
+package no.nav.foreldrepenger.fordel.web.app.forvaltning.migrering;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record MigreringJournalpostDto(@Valid @Size List<JournalpostDto> journalposter) {
+
+    public record JournalpostDto(@Size @Pattern(regexp = "^[\\p{Alnum}_.\\-]*$") String journalpostId,
+                                 @Size @Pattern(regexp = "^[\\p{Alnum}_.\\-]*$") String tilstand,
+                                 @Size @Pattern(regexp = "^[\\p{Alnum}_.\\-]*$") String kanal,
+                                 @Size @Pattern(regexp = "^[\\p{P}\\p{L}\\p{N}\\p{Alnum}\\p{Punct}\\p{Space}\\\\_.\\-]*$") String referanse) {}
+}
+

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/forvaltning/migrering/MigreringMapper.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/forvaltning/migrering/MigreringMapper.java
@@ -1,0 +1,36 @@
+package no.nav.foreldrepenger.fordel.web.app.forvaltning.migrering;
+
+import no.nav.foreldrepenger.journalføring.oppgave.lager.OppgaveEntitet;
+import no.nav.foreldrepenger.journalføring.oppgave.lager.Status;
+import no.nav.foreldrepenger.mottak.domene.dokument.Journalpost;
+
+public class MigreringMapper {
+
+    public static MigreringOppgaveDto.OppgaveDto tilOppgaveDto(OppgaveEntitet oppgave) {
+        return new MigreringOppgaveDto.OppgaveDto(oppgave.getJournalpostId(), oppgave.getEnhet(), oppgave.getFrist(), oppgave.getBrukerId(),
+            oppgave.getYtelseType(), oppgave.getBeskrivelse(), oppgave.getReservertAv());
+    }
+
+    public static OppgaveEntitet fraOppgaveDto(MigreringOppgaveDto.OppgaveDto oppgaveDto) {
+        return OppgaveEntitet.builder()
+            .medJournalpostId(oppgaveDto.journalpostId())
+            .medEnhet(oppgaveDto.enhet())
+            .medFrist(oppgaveDto.frist())
+            .medBrukerId(oppgaveDto.brukerId())
+            .medYtelseType(oppgaveDto.ytelseType())
+            .medBeskrivelse(oppgaveDto.beskrivelse())
+            .medReservertAv(oppgaveDto.reservertAv())
+            .medStatus(Status.AAPNET)
+            .build();
+    }
+
+    public static MigreringJournalpostDto.JournalpostDto tilJournalpostDto(Journalpost journalpost) {
+        return new MigreringJournalpostDto.JournalpostDto(journalpost.getJournalpostId(), journalpost.getTilstand(), journalpost.getKanal(), journalpost.getReferanse());
+    }
+
+    public static Journalpost fraJournalpostDto(MigreringJournalpostDto.JournalpostDto journalpost) {
+        return new Journalpost(journalpost.journalpostId(), journalpost.tilstand(), journalpost.kanal(), journalpost.referanse(), "FORDEL");
+    }
+
+
+}

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/forvaltning/migrering/MigreringOppgaveDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/forvaltning/migrering/MigreringOppgaveDto.java
@@ -1,0 +1,21 @@
+package no.nav.foreldrepenger.fordel.web.app.forvaltning.migrering;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import no.nav.foreldrepenger.journalføring.oppgave.lager.AktørId;
+import no.nav.foreldrepenger.journalføring.oppgave.lager.YtelseType;
+
+public record MigreringOppgaveDto(@Valid @Size List<OppgaveDto> oppgaver) {
+
+    public record OppgaveDto(@Size @Pattern(regexp = "^[\\p{Alnum}_.\\-]*$") String journalpostId,
+                             @Size @Pattern(regexp = "^[\\p{Alnum}_.\\-]*$") String enhet,
+                             LocalDate frist,
+                             @Valid AktørId brukerId,
+                             @Valid YtelseType ytelseType,
+                             @Size @Pattern(regexp = "^[\\p{P}\\p{L}\\p{N}\\p{Alnum}\\p{Punct}\\p{Space}\\\\_.\\-]*$") String beskrivelse,
+                             @Size @Pattern(regexp = "^[\\p{Alnum}_.\\-]*$") String reservertAv) {}
+}

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/forvaltning/migrering/MigreringRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/forvaltning/migrering/MigreringRestTjeneste.java
@@ -1,0 +1,130 @@
+package no.nav.foreldrepenger.fordel.web.app.forvaltning.migrering;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import java.util.function.Function;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+import no.nav.foreldrepenger.journalføring.oppgave.lager.OppgaveRepository;
+import no.nav.foreldrepenger.mottak.domene.dokument.DokumentRepository;
+import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
+import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
+import no.nav.vedtak.sikkerhet.abac.TilpassetAbacAttributt;
+import no.nav.vedtak.sikkerhet.abac.beskyttet.ActionType;
+import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
+
+@Path("/forvaltning/migrering")
+@RequestScoped
+@Transactional
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+public class MigreringRestTjeneste {
+
+    private DokumentRepository dokumentRepository;
+    private OppgaveRepository oppgaveRepository;
+
+    private Validator validator;
+
+    public MigreringRestTjeneste() {
+        // CDI
+    }
+
+    @Inject
+    public MigreringRestTjeneste(DokumentRepository dokumentRepository, OppgaveRepository oppgaveRepository) {
+        this.dokumentRepository = dokumentRepository;
+        this.oppgaveRepository = oppgaveRepository;
+        @SuppressWarnings("resource") var factory = Validation.buildDefaultValidatorFactory();
+        // hibernate validator implementations er thread-safe, trenger ikke close
+        validator = factory.getValidator();
+    }
+
+    @GET
+    @Operation(description = "Leser ut oppgaver som skal migreres", tags = "Forvaltning",
+        summary = ("Leser ut oppgaver som skal migreres"),
+        responses = {@ApiResponse(responseCode = "200", description = "Oppgaver")})
+    @Path("/lesOppgaver")
+    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.DRIFT)
+    public Response lesOppgaver() {
+        var oppgaver = oppgaveRepository.hentAlleÅpneOppgaver().stream()
+            .map(MigreringMapper::tilOppgaveDto)
+            .toList();
+        var respons = new MigreringOppgaveDto(oppgaver);
+        var violations = validator.validate(respons);
+        if (!violations.isEmpty()) {
+            var allErrors = violations.stream().map(it -> it.getPropertyPath().toString() + " :: " + it.getMessage()).toList();
+            throw new IllegalArgumentException("Valideringsfeil; " + allErrors);
+        }
+        return Response.ok(respons).build();
+    }
+
+    @POST
+    @Operation(description = "Lagrer oppgaver som skal migreres", tags = "Forvaltning",
+        summary = ("Lagre oppgaver som skal migreres"),
+        responses = {@ApiResponse(responseCode = "200", description = "Oppgaver")})
+    @Path("/lagreOppgaver")
+    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.DRIFT)
+    public Response lagreOppgaver(@TilpassetAbacAttributt(supplierClass = MigreringAbacSupplier.class)
+                                       @NotNull @Parameter(name = "oppgaver") @Valid MigreringOppgaveDto oppgaver) {
+        oppgaver.oppgaver().stream()
+            .map(MigreringMapper::fraOppgaveDto)
+            .forEach(oppgaveRepository::lagre);
+        return Response.ok().build();
+    }
+
+    @POST
+    @Operation(description = "Lagre lokale journalposter som skal migreres", tags = "Forvaltning",
+        summary = ("Lagre lokale journalposter som skal migreres"),
+        responses = {@ApiResponse(responseCode = "200", description = "Journalposter")})
+    @Path("/lagreTasks")
+    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.DRIFT)
+    public Response lagreJournal(@TilpassetAbacAttributt(supplierClass = MigreringAbacSupplier.class)
+                                   @NotNull @Parameter(name = "journalposter") @Valid MigreringJournalpostDto journalposter) {
+        journalposter.journalposter().stream()
+            .map(MigreringMapper::fraJournalpostDto)
+            .forEach(dokumentRepository::lagre);
+        return Response.ok().build();
+    }
+
+    @GET
+    @Operation(description = "Leser ut lokale journalposter som skal migreres", tags = "Forvaltning",
+        summary = ("Leser ut lokale journalposter som skal migreres"),
+        responses = {@ApiResponse(responseCode = "200", description = "Journalposter")})
+    @Path("/lesJournal")
+    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.DRIFT)
+    public Response lesJournal() {
+        var journalposter = dokumentRepository.hentAlleJournalposter().stream()
+            .map(MigreringMapper::tilJournalpostDto)
+            .toList();
+        var respons = new MigreringJournalpostDto(journalposter);
+        var violations = validator.validate(respons);
+        if (!violations.isEmpty()) {
+            var allErrors = violations.stream().map(it -> it.getPropertyPath().toString() + " :: " + it.getMessage()).toList();
+            throw new IllegalArgumentException("Valideringsfeil; " + allErrors);
+        }
+        return Response.ok(respons).build();
+    }
+
+
+    public static class MigreringAbacSupplier implements Function<Object, AbacDataAttributter> {
+
+        @Override
+        public AbacDataAttributter apply(Object obj) {
+            return AbacDataAttributter.opprett();
+        }
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/konfig/ApiConfig.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/konfig/ApiConfig.java
@@ -6,9 +6,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.ws.rs.ApplicationPath;
-import jakarta.ws.rs.core.Application;
-
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ServerProperties;
 
@@ -19,11 +16,14 @@ import io.swagger.v3.oas.integration.SwaggerConfiguration;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 import no.nav.foreldrepenger.fordel.web.app.exceptions.ConstraintViolationMapper;
 import no.nav.foreldrepenger.fordel.web.app.exceptions.GeneralRestExceptionMapper;
 import no.nav.foreldrepenger.fordel.web.app.exceptions.JsonMappingExceptionMapper;
 import no.nav.foreldrepenger.fordel.web.app.exceptions.JsonParseExceptionMapper;
 import no.nav.foreldrepenger.fordel.web.app.forvaltning.ForvaltningRestTjeneste;
+import no.nav.foreldrepenger.fordel.web.app.forvaltning.migrering.MigreringRestTjeneste;
 import no.nav.foreldrepenger.fordel.web.app.jackson.JacksonJsonConfig;
 import no.nav.foreldrepenger.fordel.web.app.rest.DokumentforsendelseRestTjeneste;
 import no.nav.foreldrepenger.fordel.web.app.rest.journalføring.FerdigstillJournalføringRestTjeneste;
@@ -62,6 +62,7 @@ public class ApiConfig extends Application {
             DokumentforsendelseRestTjeneste.class,
             JournalføringRestTjeneste.class,
             ForvaltningRestTjeneste.class,
+            MigreringRestTjeneste.class,
             OpenApiResource.class,
             MultiPartFeature.class,
             ConstraintViolationMapper.class,

--- a/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/forvaltning/migrering/MigreringRestTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/forvaltning/migrering/MigreringRestTest.java
@@ -1,0 +1,100 @@
+package no.nav.foreldrepenger.fordel.web.app.forvaltning.migrering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.foreldrepenger.fordel.kodeverdi.Journalstatus;
+import no.nav.foreldrepenger.fordel.kodeverdi.MottakKanal;
+import no.nav.foreldrepenger.journalføring.oppgave.lager.OppgaveEntitet;
+import no.nav.foreldrepenger.journalføring.oppgave.lager.OppgaveRepository;
+import no.nav.foreldrepenger.journalføring.oppgave.lager.Status;
+import no.nav.foreldrepenger.journalføring.oppgave.lager.YtelseType;
+import no.nav.foreldrepenger.mottak.domene.dokument.DokumentRepository;
+import no.nav.foreldrepenger.mottak.domene.dokument.Journalpost;
+import no.nav.vedtak.mapper.json.DefaultJsonMapper;
+
+@ExtendWith(MockitoExtension.class)
+public class MigreringRestTest {
+
+    private static final String JOURNALPOST_ID = "123456789";
+
+
+    @Mock
+    private DokumentRepository dokumentRepository;
+    @Mock
+    private OppgaveRepository oppgaveRepository;
+
+
+    @Test
+    void roundtrip_oppgaveDto() {
+        // Arrange
+        var beskrivelse = "Dette er en beskrivelse med navn og (dato)";
+        var oppgave = OppgaveEntitet.builder()
+            .medBeskrivelse(beskrivelse)
+            .medJournalpostId(JOURNALPOST_ID)
+            .medBrukerId("1111111111111")
+            .medEnhet("4444")
+            .medFrist(LocalDate.now().plusDays(1))
+            .medStatus(Status.AAPNET)
+            .medYtelseType(YtelseType.FP)
+            .build();
+        when(oppgaveRepository.hentAlleÅpneOppgaver()).thenReturn(List.of(oppgave));
+
+        var forvaltning = new MigreringRestTjeneste(dokumentRepository, oppgaveRepository);
+        var dtos = (MigreringOppgaveDto) (forvaltning.lesOppgaver().getEntity());
+        var serializedDtos = DefaultJsonMapper.toJson(dtos);
+        var deserDtos = DefaultJsonMapper.fromJson(serializedDtos, MigreringOppgaveDto.class);
+        var deserInngående = forvaltning.lagreOppgaver(deserDtos);
+
+        var hendelseCaptor = ArgumentCaptor.forClass(OppgaveEntitet.class);
+        verify(oppgaveRepository, times(1)).lagre(hendelseCaptor.capture());
+
+        var lagretInn = hendelseCaptor.getValue();
+        assertThat(lagretInn.getJournalpostId()).isEqualTo(JOURNALPOST_ID);
+        assertThat(lagretInn.getEnhet()).isEqualTo("4444");
+        assertThat(lagretInn.getFrist()).isEqualTo(LocalDate.now().plusDays(1));
+        assertThat(lagretInn.getBeskrivelse()).isEqualTo(beskrivelse);
+        assertThat(lagretInn.getStatus()).isEqualTo(Status.AAPNET);
+        assertThat(lagretInn.getYtelseType()).isEqualTo(YtelseType.FP);
+
+    }
+
+
+    @Test
+    void roundtrip_journalpostDto() {
+        // Arrange
+        var ref = UUID.randomUUID().toString();
+        var journalpost = new Journalpost(JOURNALPOST_ID, Journalstatus.MOTTATT.name(), MottakKanal.ALTINN.name(), ref, "FORDEL");
+        when(dokumentRepository.hentAlleJournalposter()).thenReturn(List.of(journalpost));
+
+        var forvaltning = new MigreringRestTjeneste(dokumentRepository, oppgaveRepository);
+        var dtos = (MigreringJournalpostDto) (forvaltning.lesJournal().getEntity());
+        var serializedDtos = DefaultJsonMapper.toJson(dtos);
+        var deserDtos = DefaultJsonMapper.fromJson(serializedDtos, MigreringJournalpostDto.class);
+        var deserInngående = forvaltning.lagreJournal(deserDtos);
+
+        var hendelseCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(dokumentRepository, times(1)).lagre(hendelseCaptor.capture());
+
+        var lagretInn = (Journalpost) hendelseCaptor.getValue();
+        assertThat(lagretInn.getJournalpostId()).isEqualTo(JOURNALPOST_ID);
+        assertThat(lagretInn.getTilstand()).isEqualTo("MOTTATT");
+        assertThat(lagretInn.getKanal()).isEqualTo("ALTINN");
+        assertThat(lagretInn.getReferanse()).isEqualTo(ref);
+        assertThat(lagretInn.getOpprettetAv()).isEqualTo("FORDEL");
+
+    }
+
+}


### PR DESCRIPTION
Litt forberedelser til den tiden vi vil se på migrering til postgres.
Fordel er mer komplisert enn abonnent siden den har 2 inputs: Søknad/Rest og Kafka.
Tenker vi først deployer den uten kafka-lesing, så en deploy uten rest-mottak (exception) som kjører 10-20s (hente data + send inn søknader), før deploy av PG med rest u/kafka. Last opp data hentet ut. Deploy pG med kafka. 
Deploy en ORCL-versjon som heter "runoff" som er ferdig på et par timer.