### PR TITLE
TFP-5791: Tillater å endre tittel om det er kun 1 dokument og den er forskjellig fra journalpost tittel.

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringRestTjeneste.java
@@ -92,9 +92,9 @@ public class FerdigstillJournalføringRestTjeneste {
         List<FerdigstillJournalføringTjeneste.DokumenterMedNyTittel> dokumenter = new ArrayList<>();
         String nyJournalpostTittel = null;
         DokumentTypeId nyDokumentTypeId = null;
-        if (request.oppdaterTitlerDto != null) {
-            if (!request.oppdaterTitlerDto.dokumenter().isEmpty()) {
-                dokumenter = mapTilDokumenter(request.oppdaterTitlerDto.dokumenter());
+        if (request.oppdaterTitlerDto() != null) {
+            if (!request.oppdaterTitlerDto().dokumenter().isEmpty()) {
+                dokumenter = mapTilDokumenter(request.oppdaterTitlerDto().dokumenter());
             }
             nyJournalpostTittel = request.oppdaterTitlerDto().journalpostTittel() != null ? request.oppdaterTitlerDto().journalpostTittel() : null;
             if (nyJournalpostTittel != null) {


### PR DESCRIPTION
Gjelder primært om SBH klarte å endre Journalpost tittel i Gosys men endret ikke Dokument tittel.