### PR TITLE
Behandle IM fra NavNo annerledes enn ALTINN

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/MottattStrukturertDokument.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/MottattStrukturertDokument.java
@@ -31,7 +31,7 @@ public abstract class MottattStrukturertDokument<S> {
     }
 
     public final void kopierTilMottakWrapper(MottakMeldingDataWrapper dataWrapper, Function<String, Optional<String>> aktørIdFinder) {
-        validerSkjemaSemantisk(dataWrapper);
+        validerSkjemaSemantisk(dataWrapper, aktørIdFinder);
         kopierVerdier(dataWrapper, aktørIdFinder);
     }
 
@@ -54,9 +54,10 @@ public abstract class MottattStrukturertDokument<S> {
      * <p>
      * Hvis ingen slik validering er nødvendig, kan du bare returne.
      *
-     * @param dataWrapper data holder som skal populeres med verdier fra skjema
+     * @param dataWrapper   data holder som skal populeres med verdier fra skjema
+     * @param aktørIdFinder
      */
-    protected abstract void validerSkjemaSemantisk(MottakMeldingDataWrapper dataWrapper);
+    protected abstract void validerSkjemaSemantisk(MottakMeldingDataWrapper dataWrapper, Function<String, Optional<String>> aktørIdFinder);
 
     public S getSkjema() {
         return skjema;

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/v1/Inntektsmelding.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/v1/Inntektsmelding.java
@@ -4,13 +4,13 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.function.Function;
 
-import jakarta.xml.bind.JAXBElement;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jakarta.xml.bind.JAXBElement;
 import no.nav.foreldrepenger.mottak.domene.MottattStrukturertDokument;
 import no.nav.foreldrepenger.mottak.felles.MottakMeldingDataWrapper;
+import no.nav.vedtak.exception.FunksjonellException;
 import no.nav.vedtak.exception.TekniskException;
 import no.seres.xsd.nav.inntektsmelding_m._20180924.InntektsmeldingM;
 import no.seres.xsd.nav.inntektsmelding_m._20180924.Skjemainnhold;
@@ -44,8 +44,14 @@ public class Inntektsmelding extends MottattStrukturertDokument<InntektsmeldingM
     }
 
     @Override
-    protected void validerSkjemaSemantisk(MottakMeldingDataWrapper dataWrapper) {
-        // Ikke gjør noe
+    protected void validerSkjemaSemantisk(MottakMeldingDataWrapper dataWrapper, Function<String, Optional<String>> aktørIdFinder) {
+        Optional<String> aktørIdFraSkjema = aktørIdFinder.apply(getArbeidstakerFnr());
+        Optional<String> aktørIdFraJournalpost = dataWrapper.getAktørId();
+        if (aktørIdFraJournalpost.isPresent()) {
+            if (aktørIdFraSkjema.filter(aktørIdFraJournalpost.get()::equals).isEmpty()) {
+                throw new FunksjonellException("FP-401245", "Ulike personer i journalpost og inntektsmelding.", null);
+            }
+        }
     }
 
     private LocalDate getStartdatoForeldrepengeperiode() {

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/v1/Inntektsmelding.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/v1/Inntektsmelding.java
@@ -49,7 +49,7 @@ public class Inntektsmelding extends MottattStrukturertDokument<InntektsmeldingM
         Optional<String> aktørIdFraJournalpost = dataWrapper.getAktørId();
         if (aktørIdFraJournalpost.isPresent()) {
             if (aktørIdFraSkjema.filter(aktørIdFraJournalpost.get()::equals).isEmpty()) {
-                throw new FunksjonellException("FP-401245", "Ulike personer i journalpost og inntektsmelding.", null);
+                throw new FunksjonellException("FP-401246", "Ulike personer i journalpost og inntektsmelding.", null);
             }
         }
     }

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/v2/Inntektsmelding.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/v2/Inntektsmelding.java
@@ -64,7 +64,7 @@ public class Inntektsmelding extends MottattStrukturertDokument<InntektsmeldingM
         Optional<String> aktørIdFraJournalpost = dataWrapper.getAktørId();
         if (aktørIdFraJournalpost.isPresent()) {
             if (aktørIdFraSkjema.filter(aktørIdFraJournalpost.get()::equals).isEmpty()) {
-                throw new FunksjonellException("FP-401245", "Ulike personer i journalpost og inntektsmelding.", null);
+                throw new FunksjonellException("FP-401246", "Ulike personer i journalpost og inntektsmelding.", null);
             }
         }
     }

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/v2/Inntektsmelding.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/v2/Inntektsmelding.java
@@ -5,13 +5,13 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.function.Function;
 
-import jakarta.xml.bind.JAXBElement;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jakarta.xml.bind.JAXBElement;
 import no.nav.foreldrepenger.mottak.domene.MottattStrukturertDokument;
 import no.nav.foreldrepenger.mottak.felles.MottakMeldingDataWrapper;
+import no.nav.vedtak.exception.FunksjonellException;
 import no.nav.vedtak.exception.TekniskException;
 import no.seres.xsd.nav.inntektsmelding_m._20181211.Arbeidsforhold;
 import no.seres.xsd.nav.inntektsmelding_m._20181211.Arbeidsgiver;
@@ -59,8 +59,14 @@ public class Inntektsmelding extends MottattStrukturertDokument<InntektsmeldingM
     }
 
     @Override
-    protected void validerSkjemaSemantisk(MottakMeldingDataWrapper dataWrapper) {
-        // Ikke gjør noe
+    protected void validerSkjemaSemantisk(MottakMeldingDataWrapper dataWrapper, Function<String, Optional<String>> aktørIdFinder) {
+        Optional<String> aktørIdFraSkjema = aktørIdFinder.apply(getArbeidstakerFnr());
+        Optional<String> aktørIdFraJournalpost = dataWrapper.getAktørId();
+        if (aktørIdFraJournalpost.isPresent()) {
+            if (aktørIdFraSkjema.filter(aktørIdFraJournalpost.get()::equals).isEmpty()) {
+                throw new FunksjonellException("FP-401245", "Ulike personer i journalpost og inntektsmelding.", null);
+            }
+        }
     }
 
     private LocalDate getStartdatoForeldrepengeperiode() {

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/v3/Søknad.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/domene/v3/Søknad.java
@@ -10,7 +10,6 @@ import java.util.UUID;
 import java.util.function.Function;
 
 import jakarta.xml.bind.JAXBElement;
-
 import no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema;
 import no.nav.foreldrepenger.mottak.domene.MottattStrukturertDokument;
 import no.nav.foreldrepenger.mottak.felles.MottakMeldingDataWrapper;
@@ -79,7 +78,7 @@ public class Søknad extends MottattStrukturertDokument<Soeknad> {
     }
 
     @Override
-    protected void validerSkjemaSemantisk(MottakMeldingDataWrapper dataWrapper) {
+    protected void validerSkjemaSemantisk(MottakMeldingDataWrapper dataWrapper, Function<String, Optional<String>> aktørIdFinder) {
         sjekkNødvendigeFeltEksisterer(dataWrapper.getForsendelseId().orElse(null));
         final BehandlingTema behandlingTema = hentBehandlingTema();
         final String aktørId = getSkjema().getSoeker().getAktoerId();

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/felles/MottakMeldingDataWrapper.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/felles/MottakMeldingDataWrapper.java
@@ -155,14 +155,6 @@ public class MottakMeldingDataWrapper {
         prosessTaskData.setProperty(SAKSNUMMER_KEY, saksnummer);
     }
 
-    public Optional<String> getInnkommendeSaksnummer() {
-        return Optional.ofNullable(prosessTaskData.getPropertyValue(INN_SAKSNR_KEY));
-    }
-
-    public void setInnkommendeSaksnummer(String saksnummer) {
-        prosessTaskData.setProperty(INN_SAKSNR_KEY, saksnummer);
-    }
-
     public Optional<DokumentTypeId> getDokumentTypeId() {
         return Optional.ofNullable(prosessTaskData.getPropertyValue(DOKUMENTTYPE_ID_KEY)).map(DokumentTypeId::fraKodeDefaultUdefinert);
     }

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/journal/ArkivTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/journal/ArkivTjeneste.java
@@ -241,6 +241,14 @@ public class ArkivTjeneste {
         }
     }
 
+    public void oppdaterTilleggsopplysning(String journalpostId, DokumentTypeId dokumentTypeId) {
+        var builder = OppdaterJournalpostRequest.ny()
+            .leggTilTilleggsopplysning(new Tilleggsopplysning(FP_DOK_TYPE, dokumentTypeId.getOffisiellKode()));
+        if (!dokArkivTjeneste.oppdaterJournalpost(journalpostId, builder.build())) {
+            throw new IllegalStateException(KUNNE_IKKE_OPPDATERE_JP + journalpostId);
+        }
+    }
+
     public void oppdaterJournalpostBruker(String journalpostId, String fødselsnummer) {
         var aktørId = personTjeneste.hentAktørIdForPersonIdent(fødselsnummer).orElseThrow();
         if (!dokArkivTjeneste.oppdaterJournalpost(journalpostId, OppdaterJournalpostRequest.ny().medBruker(aktørId).build())) {

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/journal/ArkivTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/journal/ArkivTjeneste.java
@@ -241,14 +241,6 @@ public class ArkivTjeneste {
         }
     }
 
-    public void oppdaterTilleggsopplysning(String journalpostId, DokumentTypeId dokumentTypeId) {
-        var builder = OppdaterJournalpostRequest.ny()
-            .leggTilTilleggsopplysning(new Tilleggsopplysning(FP_DOK_TYPE, dokumentTypeId.getOffisiellKode()));
-        if (!dokArkivTjeneste.oppdaterJournalpost(journalpostId, builder.build())) {
-            throw new IllegalStateException(KUNNE_IKKE_OPPDATERE_JP + journalpostId);
-        }
-    }
-
     public void oppdaterJournalpostBruker(String journalpostId, String fødselsnummer) {
         var aktørId = personTjeneste.hentAktørIdForPersonIdent(fødselsnummer).orElseThrow();
         if (!dokArkivTjeneste.oppdaterJournalpost(journalpostId, OppdaterJournalpostRequest.ny().medBruker(aktørId).build())) {
@@ -258,28 +250,27 @@ public class ArkivTjeneste {
 
     public void settTilleggsOpplysninger(ArkivJournalpost arkivJournalpost, DokumentTypeId defaultDokumentTypeId, boolean manuellJournalføring) {
         var journalpost = arkivJournalpost.getOriginalJournalpost();
-        var tilleggDokumentType = arkivJournalpost.getTilleggsopplysninger().stream().filter(to -> FP_DOK_TYPE.equals(to.nokkel())).findFirst();
-        var hovedtype = DokumentTypeId.UDEFINERT.equals(arkivJournalpost.getHovedtype()) ? defaultDokumentTypeId : arkivJournalpost.getHovedtype();
+        var tilleggDoktype = arkivJournalpost.getTilleggsopplysninger().stream().filter(to -> FP_DOK_TYPE.equals(to.nokkel())).toList();
+        var tilleggAnnet = arkivJournalpost.getTilleggsopplysninger().stream().filter(to -> !FP_DOK_TYPE.equals(to.nokkel())).toList();
         //saksbehandler kan ha valgt ny tittel ifm manuellJournalføring
-        if (manuellJournalføring) {
-            hovedtype = defaultDokumentTypeId;
+        var hovedtype = manuellJournalføring || DokumentTypeId.UDEFINERT.equals(arkivJournalpost.getHovedtype()) ?
+            defaultDokumentTypeId : arkivJournalpost.getHovedtype();
+
+        if (DokumentTypeId.UDEFINERT.equals(hovedtype)) {
+            return;
         }
 
-        if (tilleggDokumentType.isEmpty() || !arkivJournalpost.getHovedtype().equals(defaultDokumentTypeId) ) {
+        if (tilleggDoktype.isEmpty() || tilleggDoktype.stream().noneMatch(to -> hovedtype.getOffisiellKode().equals(to.verdi()))) {
             var builder = OppdaterJournalpostRequest.ny();
             if (LOG.isInfoEnabled()) {
                 LOG.info("FPFORDEL oppdaterer/legger til tilleggsopplysninger for {} med {}", journalpost.journalpostId(), hovedtype.getOffisiellKode());
             }
-            if (!arkivJournalpost.getTilleggsopplysninger().isEmpty()) {
-                builder.medTilleggsopplysninger(arkivJournalpost.getTilleggsopplysninger());
+            if (!tilleggAnnet.isEmpty()) {
+                builder.medTilleggsopplysninger(tilleggAnnet);
             }
             builder.leggTilTilleggsopplysning(new Tilleggsopplysning(FP_DOK_TYPE, hovedtype.getOffisiellKode()));
             if (!dokArkivTjeneste.oppdaterJournalpost(journalpost.journalpostId(), builder.build())) {
                 throw new IllegalStateException(KUNNE_IKKE_OPPDATERE_JP + journalpost.journalpostId());
-            }
-        } else {
-            if (LOG.isInfoEnabled()) {
-                LOG.info("FPFORDEL tilleggsopplysninger allerede satt for {} med {}", journalpost.journalpostId(), tilleggDokumentType);
             }
         }
     }

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/task/TilJournalføringTask.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/task/TilJournalføringTask.java
@@ -84,26 +84,26 @@ public class TilJournalføringTask extends WrappedProsessTaskHandler {
             var journalpost = arkivTjeneste.hentArkivJournalpost(w.getArkivId());
             arkivTjeneste.settTilleggsOpplysninger(journalpost, w.getDokumentTypeId().orElse(DokumentTypeId.UDEFINERT), false);
         } catch (Exception e) {
-            LOG.info("Feil ved setting av tilleggsopplysninger for journalpostId {}", w.getArkivId());
+            LOG.info("FORDEL OPPRETT/FERDIG Feil ved setting av tilleggsopplysninger for journalpostId {}", w.getArkivId());
         }
         // Annet dokument fra dokumentmottak (scanning, altinn). Kan skippe
         // unntakshåndtering. Bør feile.
         try {
-            var innkommendeSaksnummer = w.getInnkommendeSaksnummer();
-            if (innkommendeSaksnummer.isPresent()) {
-                LOG.info("FORDEL OPPRETT/FERDIG presatt saksnummer {} for journalpost {}", innkommendeSaksnummer.get(), w.getArkivId());
+            var journalpost = arkivTjeneste.hentArkivJournalpost(w.getArkivId());
+            if (journalpost.getSaksnummer().filter(s -> s.equals(saksnummer)).isPresent()) {
+                LOG.info("FORDEL OPPRETT/FERDIG presatt saksnummer {} for journalpost {}", saksnummer, w.getArkivId());
             } else {
                 arkivTjeneste.oppdaterMedSak(w.getArkivId(), saksnummer, w.getAktørId().orElseThrow());
             }
             arkivTjeneste.ferdigstillJournalføring(w.getArkivId(), w.getJournalførendeEnhet().orElse(AUTOMATISK_ENHET));
         } catch (Exception e) {
-            LOG.warn("Feil journaltilstand. Forventet tilstand: endelig, fikk Midlertidig");
+            LOG.warn("FORDEL OPPRETT/FERDIG Feil journaltilstand. Forventet tilstand: endelig, fikk Midlertidig");
             return w.nesteSteg(TaskType.forProsessTask(OpprettGSakOppgaveTask.class));
         }
         try {
             oppgave.ferdigstillAlleÅpneJournalføringsoppgaverFor(JournalpostId.fra(w.getArkivId()));
         } catch (Exception e) {
-            LOG.info("FPFORDEL JFR-OPPGAVE: feil ved ferdigstilling av åpne oppgaver for journalpostId: {}", w.getArkivId());
+            LOG.warn("FPFORDEL JFR-OPPGAVE: feil ved ferdigstilling av åpne oppgaver for journalpostId: {}", w.getArkivId());
         }
         return w.nesteSteg(TaskType.forProsessTask(VLKlargjørerTask.class));
     }

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/task/dokumentforsendelse/BehandleDokumentforsendelseTask.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/task/dokumentforsendelse/BehandleDokumentforsendelseTask.java
@@ -202,8 +202,7 @@ public class BehandleDokumentforsendelseTask extends WrappedProsessTaskHandler {
             var journalpost = opprettJournalpostFerdigstillHvisSaksnummer(forsendelseId, w, destinasjon.saksnummer());
             w.setArkivId(journalpost.journalpostId());
             if (!journalpost.ferdigstilt()) {
-                // Det vil komme en Kafka-hendelse om noen sekunder - denne sørger for at vi
-                // ikke trigger på den.
+                // Det vil komme en Kafka-hendelse om noen sekunder - denne sørger for at vi ikke trigger på den.
                 dokumentRepository.lagreJournalpostLokal(w.getArkivId(), SELVBETJENING.getKode(), "MIDLERTIDIG", forsendelseId.toString());
             }
             return utledNesteSteg(w, forsendelseId, destinasjon, journalpost.ferdigstilt());
@@ -267,7 +266,7 @@ public class BehandleDokumentforsendelseTask extends WrappedProsessTaskHandler {
 
     private MottakMeldingDataWrapper utledNesteSteg(MottakMeldingDataWrapper w, UUID forsendelseId, Destinasjon destinasjon, boolean ferdigstilt) {
         LOG.info("FPFORDEL BdTask exit {}", destinasjon);
-        if (GOSYS.equals(destinasjon.system()) || ((destinasjon.saksnummer() != null) && !ferdigstilt)) {
+        if (GOSYS.equals(destinasjon.system()) || (destinasjon.saksnummer() != null && !ferdigstilt)) {
             dokumentRepository.oppdaterForsendelseMedArkivId(forsendelseId, w.getArkivId(), GOSYS);
             w.setSaksnummer(null);
             return w.nesteSteg(TaskType.forProsessTask(OpprettGSakOppgaveTask.class));

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/task/joark/HentDataFraJoarkTask.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/task/joark/HentDataFraJoarkTask.java
@@ -172,10 +172,16 @@ public class HentDataFraJoarkTask extends WrappedProsessTaskHandler {
                     // Skyldes feil i IM eller spesiell bruk av Gosys. Lag oppgave i dette tilfelle, godta i BehandleDokumentService
                     if ("FP-401245".equals(vle.getKode())) {
                         w.setSaksnummer(null);
-                        LOG.warn("FPFORDEL HentFraArkiv avvik for journalpost vs XML journalpostId {} avvik {}",
+                        LOG.warn("FPFORDEL HentFraArkiv avvik saksnummer for journalpost vs XML journalpostId {} avvik {}",
                             journalpost.getJournalpostId(), vle.getFeilmelding());
                         return w.nesteSteg(TASK_GOSYS);
                     }
+                    if ("FP-401246".equals(vle.getKode())) {
+                        LOG.warn("FPFORDEL HentFraArkiv avvik person for journalpost vs XML journalpostId {} avvik {}",
+                            journalpost.getJournalpostId(), vle.getFeilmelding());
+                        throw vle;
+                    }
+                    throw vle;
                 }
             }
         }
@@ -267,13 +273,13 @@ public class HentDataFraJoarkTask extends WrappedProsessTaskHandler {
 
     private void sjekkOgOppdaterInntektsmeldingSelvbetjent(MottakMeldingDataWrapper w, ArkivJournalpost j, String aktørIdJournalpost) {
         if (aktørIdJournalpost == null) {
-            throw new TekniskException("FP-429672", "Mangler Bruker på Innteksmelding fra NavNo");
+            throw new TekniskException("FP-429672", "Mangler Bruker på IM-journalpost fra NavNo");
         }
         if (!FORELDRE_OG_SVANGERSKAPSPENGER.equals(j.getTema())) {
-            throw new TekniskException("FP-429675", "Mangler Tema på Innteksmelding fra NavNo");
+            throw new TekniskException("FP-429675", "Mangler Tema på IM-journalpost fra NavNo");
         }
         if (!Set.of(BehandlingTema.FORELDREPENGER, BehandlingTema.SVANGERSKAPSPENGER).contains(j.getBehandlingstema())) {
-            throw new TekniskException("FP-429674", "Mangler BehandlingTema på Innteksmelding fra NavNo");
+            throw new TekniskException("FP-429674", "Mangler BehandlingTema på IM-journalpost fra NavNo");
         }
         var behandlingTemaFraIM = w.getInntektsmeldingYtelse().map(BehandlingTema::fraTermNavn)
             .orElseThrow(() -> new TekniskException("FP-429673", "Mangler Ytelse på Innteksmelding"));

--- a/domene/src/test/java/no/nav/foreldrepenger/mottak/task/OpprettSakTaskTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/mottak/task/OpprettSakTaskTest.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -140,6 +141,10 @@ class OpprettSakTaskTest {
     @Test
     void test_doTask_svangerskapspenger_inntektsmelding() throws Exception {
 
+        var aktørId = "1000104134079";
+
+        when(aktørConsumer.hentAktørIdForPersonIdent(any())).thenReturn(Optional.of(aktørId));
+
         var prosessTaskData = ProsessTaskData.forProsessTask(HentDataFraJoarkTask.class);
 
         String filename = "testsoknader/inntektsmelding-svp.xml";
@@ -148,7 +153,7 @@ class OpprettSakTaskTest {
 
         var ptData = new MottakMeldingDataWrapper(prosessTaskData);
         ptData.setArkivId("123");
-        ptData.setAktørId("1000104134079");
+        ptData.setAktørId(aktørId);
         ptData.setBehandlingTema(BehandlingTema.SVANGERSKAPSPENGER);
         ptData.setDokumentKategori(DokumentKategori.UDEFINERT);
 

--- a/domene/src/test/java/no/nav/foreldrepenger/mottak/task/joark/HentDataFraJoarkTaskTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/mottak/task/joark/HentDataFraJoarkTaskTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -246,7 +245,6 @@ class HentDataFraJoarkTaskTest {
         BehandlingTema actualBehandlingTema = BehandlingTema.UDEFINERT;
         dataWrapper.setBehandlingTema(actualBehandlingTema);
         dataWrapper.setTema(Tema.FORELDRE_OG_SVANGERSKAPSPENGER);
-        dataWrapper.setInnkommendeSaksnummer("VL");
         dataWrapper.setSaksnummer("VL");
 
 
@@ -263,7 +261,6 @@ class HentDataFraJoarkTaskTest {
         when(vurderVLSaker.bestemDestinasjon(any())).thenReturn(new Destinasjon(ForsendelseStatus.FPSAK, "VL"));
 
         BehandlingTema actualBehandlingTema = BehandlingTema.UDEFINERT;
-        dataWrapper.setInnkommendeSaksnummer("VL");
         dataWrapper.setSaksnummer("VL");
         dataWrapper.setBehandlingTema(actualBehandlingTema);
         dataWrapper.setTema(Tema.FORELDRE_OG_SVANGERSKAPSPENGER);

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjeneste.java
@@ -500,7 +500,7 @@ public class FerdigstillJournalføringTjeneste {
             mottattDokument.kopierTilMottakWrapper(dataWrapper, pdl::hentAktørIdForPersonIdent);
         } catch (FunksjonellException e) {
             // Her er det "greit" - da har man bestemt seg, men kan lage rot i saken.
-            if ("FP-401245".equals(e.getKode())) {
+            if ("FP-401245".equals(e.getKode()) || "FP-401246".equals(e.getKode())) {
                 var logMessage = e.getMessage();
                 LOG.info("FPFORDEL RESTJOURNALFØRING: {}", logMessage);
             } else {

--- a/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjenesteTest.java
@@ -74,7 +74,6 @@ class FerdigstillJournalføringTjenesteTest {
     private static final String JOURNALPOST_ID = "123";
     private static final String ENHETID = "4567";
     private static final String SAKSNUMMER = "789";
-    private static final String OPPGAVE_ID = "123456L";
     private static final String AKTØR_ID = "9000000000009";
     @Mock
     private VLKlargjører klargjører;
@@ -171,6 +170,7 @@ class FerdigstillJournalføringTjenesteTest {
         when(arkivJournalpost.getHovedtype()).thenReturn(DokumentTypeId.INNTEKTSMELDING);
         when(fagsak.finnFagsakInfomasjon(ArgumentMatchers.any())).thenReturn(
             Optional.of(new FagsakInfomasjonDto(AKTØR_ID, FORELDREPENGER_FØDSEL.getOffisiellKode())));
+        when(pdl.hentAktørIdForPersonIdent(any())).thenReturn(Optional.of(AKTØR_ID));
 
         when(arkivJournalpost.getInnholderStrukturertInformasjon()).thenReturn(true);
         when(arkivJournalpost.getStrukturertPayload()).thenReturn(readFile("testdata/inntektsmelding-foreldrepenger.xml"));


### PR DESCRIPTION
Altinn-håndteringen setter bruker (fra innhold i IM). 
Dokarkiv fjerner evt sakstilknytning satt av fp-inntektsmelding når bruker endres (også til samme bruker).

Hovedendringer
* Vil ikke oppdatere bruker for NavNo-IM. Når denne er merget kan FP-im sette Sak (men kan ikke ferdigstille)
* Sjekk: At journalposten har satt bruker / aktørId eller fnr
* Sjekk: At fnr inne i XML er samme person som bruker på journalposten
* Sjekk: At tema er satt
* Sjekk: At behandlingstema er satt på journalpost og at den stemmer med ytelse inne i XML