### PR TITLE
Kall rutingtjeneste og sammenlign. Siste felles

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/behandlendeenhet/RutingKlient.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/behandlendeenhet/RutingKlient.java
@@ -1,0 +1,43 @@
+package no.nav.foreldrepenger.mottak.behandlendeenhet;
+
+import java.net.URI;
+import java.util.Set;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.core.UriBuilder;
+import no.nav.vedtak.felles.integrasjon.rest.FpApplication;
+import no.nav.vedtak.felles.integrasjon.rest.RestClient;
+import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
+import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
+
+@Dependent
+@RestClientConfig(tokenConfig = TokenFlow.AZUREAD_CC, application = FpApplication.FPTILGANG)
+public class RutingKlient {
+
+    private final URI rutingUri;
+    private final RestClient klient;
+    private final RestConfig restConfig;
+
+    public RutingKlient() {
+        this.klient = RestClient.client();
+        this.restConfig = RestConfig.forClient(this.getClass());
+        this.rutingUri = UriBuilder.fromUri(restConfig.fpContextPath())
+            .path("/api/ruting/egenskaper")
+            .build();
+    }
+
+    public Set<RutingResultat> finnRutingEgenskaper(Set<String> aktørIdenter) {
+        var request = new RutingRequest(aktørIdenter);
+        var rrequest = RestRequest.newPOSTJson(request, rutingUri, restConfig);
+        return klient.sendReturnOptional(rrequest, RutingRespons.class).map(RutingRespons::resultater).orElseGet(Set::of);
+    }
+
+
+    public record RutingRequest(@Valid Set<String> aktørIdenter) { }
+
+    public record RutingRespons(Set<RutingResultat> resultater) { }
+
+}

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/behandlendeenhet/RutingResultat.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/behandlendeenhet/RutingResultat.java
@@ -1,0 +1,7 @@
+package no.nav.foreldrepenger.mottak.behandlendeenhet;
+
+public enum RutingResultat {
+    STRENGTFORTROLIG,
+    SKJERMING,
+    UTLAND
+}

--- a/domene/src/test/java/no/nav/foreldrepenger/mottak/behandlendeenhet/EnhetsTjenesteTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/mottak/behandlendeenhet/EnhetsTjenesteTest.java
@@ -36,6 +36,8 @@ class EnhetsTjenesteTest {
     private PersonInformasjon personTjeneste;
     @Mock
     private Skjerming skjermetPersonKlient;
+    @Mock
+    private RutingKlient rutingKlient;
 
     @BeforeEach
     void setup() {
@@ -43,7 +45,7 @@ class EnhetsTjenesteTest {
         when(arbeidsfordeling.hentAlleAktiveEnheter(any())).thenReturn(List.of(FORDELING_ENHET));
         when(arbeidsfordeling.finnEnhet(any())).thenReturn(List.of(ENHET));
         when(personTjeneste.hentGeografiskTilknytning(any(), any())).thenReturn(GEOGRAFISK_TILKNYTNING);
-        enhetsTjeneste = new EnhetsTjeneste(personTjeneste, arbeidsfordeling, skjermetPersonKlient);
+        enhetsTjeneste = new EnhetsTjeneste(personTjeneste, arbeidsfordeling, skjermetPersonKlient, rutingKlient);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <sonar.projectName>fp-fordel</sonar.projectName>
         <sonar.projectKey>navikt_fpfordel</sonar.projectKey>
 
-        <felles.version>7.4.4</felles.version>
+        <felles.version>7.4.5</felles.version>
         <prosesstask.version>5.1.1</prosesstask.version>
         <fp-kontrakter.version>9.2.1</fp-kontrakter.version>
 


### PR DESCRIPTION
Tar inn felles 7.4.5 som kaller ny tilgangskontroll, sammenligner svar med gammel abac-kontroll og logger likhet/diff
Prøvde en stund, men hadde en skrivefeil i scope til pdl-pip-api.

Tar også inn kall til ruting-tjeneste i fptilgang som skal gi svar på fordeling av behandling til riktig enhet. Sammenligner med dagens logikk og logger avvik. Ved å sentralisere rutingtjenesten, kan vi fjerne bruken av skjermet-person-pip i fpfordel og fpsak.