### PR TITLE
Et par feilscenarier

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/hendelse/JournalføringHendelseHåndterer.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/hendelse/JournalføringHendelseHåndterer.java
@@ -1,41 +1,37 @@
 package no.nav.foreldrepenger.mottak.hendelse;
 
+import static io.confluent.kafka.serializers.KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG;
+
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.function.Supplier;
-
-import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.context.control.ActivateRequestContext;
-import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
-
-import no.nav.foreldrepenger.konfig.Environment;
-import no.nav.foreldrepenger.konfig.KonfigVerdi;
-
-import no.nav.foreldrepenger.mottak.hendelse.test.VtpKafkaAvroDeserializer;
-import no.nav.vedtak.felles.integrasjon.kafka.KafkaMessageHandler;
-
-import no.nav.vedtak.felles.integrasjon.kafka.KafkaProperties;
 
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema;
 import no.nav.foreldrepenger.fordel.kodeverdi.MottakKanal;
 import no.nav.foreldrepenger.fordel.kodeverdi.Tema;
+import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.foreldrepenger.konfig.KonfigVerdi;
 import no.nav.foreldrepenger.mottak.domene.dokument.DokumentRepository;
 import no.nav.foreldrepenger.mottak.felles.MottakMeldingDataWrapper;
+import no.nav.foreldrepenger.mottak.hendelse.test.VtpKafkaAvroDeserializer;
 import no.nav.foreldrepenger.mottak.task.joark.HentDataFraJoarkTask;
 import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord;
+import no.nav.vedtak.felles.integrasjon.kafka.KafkaMessageHandler;
+import no.nav.vedtak.felles.integrasjon.kafka.KafkaProperties;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.vedtak.log.mdc.MDCOperations;
-
-import static io.confluent.kafka.serializers.KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG;
 
 /*
  * Dokumentasjon https://confluence.adeo.no/pages/viewpage.action?pageId=315215917
@@ -116,7 +112,7 @@ public class JournalføringHendelseHåndterer implements KafkaMessageHandler<Str
 
         if (HENDELSE_ENDRET.equalsIgnoreCase(payload.getHendelsesType())) {
             // Hendelsen kan komme før arkivet er oppdatert .....
-            delay = Duration.ofSeconds(30);
+            delay = Duration.ofSeconds(40);
             var gammeltTema = payload.getTemaGammelt() != null ? payload.getTemaGammelt() : null;
             LOG.info("FPFORDEL Tema Endret fra {} journalpost {} kanal {} referanse {}", gammeltTema, arkivId, mottaksKanal, eksternReferanseId);
         }

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/journal/ArkivTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/journal/ArkivTjeneste.java
@@ -179,8 +179,8 @@ public class ArkivTjeneste {
 
         if (infoList.size() > 1) {
             throw new IllegalStateException("Journalposten har flere dokumenter med VariantFormat = ORIGINAL");
-        } else if (!infoList.isEmpty()) {
-            var dokumentInfo = infoList.get(0);
+        } else if (!infoList.isEmpty() && Tema.FORELDRE_OG_SVANGERSKAPSPENGER.equals(Tema.fraOffisiellKode(journalpost.tema()))) {
+            var dokumentInfo = infoList.getFirst();
             var payload = saf.hentDokument(journalpostId, dokumentInfo, Dokumentvariant.Variantformat.ORIGINAL);
             builder.medStrukturertPayload(payload).medDokumentInfoId(dokumentInfo);
         }
@@ -209,7 +209,7 @@ public class ArkivTjeneste {
     }
 
     public Optional<String> hentEksternReferanseId(Journalpost journalpost) {
-        var dokumentInfoId = journalpost.dokumenter().get(0).dokumentInfoId();
+        var dokumentInfoId = journalpost.dokumenter().getFirst().dokumentInfoId();
         var referanse = saf.hentEksternReferanseId(dokumentInfoId).stream().map(Journalpost::eksternReferanseId).filter(Objects::nonNull).findFirst();
         var loggtekst = referanse.orElse("ingen");
         if (LOG.isInfoEnabled()) {

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/person/PersonInformasjon.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/person/PersonInformasjon.java
@@ -10,6 +10,8 @@ public interface PersonInformasjon {
 
     Optional<String> hentPersonIdentForAktørId(String id);
 
+    boolean erMann(BehandlingTema behandlingTema, String id);
+
     String hentNavn(BehandlingTema behandlingTema, String id);
 
 }

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/person/PersonTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/person/PersonTjeneste.java
@@ -11,6 +11,8 @@ import jakarta.inject.Inject;
 import no.nav.foreldrepenger.fordel.StringUtil;
 import no.nav.foreldrepenger.fordel.kodeverdi.BehandlingTema;
 import no.nav.pdl.HentPersonQueryRequest;
+import no.nav.pdl.KjoennResponseProjection;
+import no.nav.pdl.KjoennType;
 import no.nav.pdl.Navn;
 import no.nav.pdl.NavnResponseProjection;
 import no.nav.pdl.PersonResponseProjection;
@@ -76,6 +78,16 @@ public class PersonTjeneste implements PersonInformasjon {
             LOG.warn("Kunne ikke hente fnr fra aktørid {}", aktørId, e);
             return Optional.empty();
         }
+    }
+
+    @Override
+    public boolean erMann(BehandlingTema behandlingTema, String id) {
+        var ytelse = utledYtelse(behandlingTema);
+        return pdl.hentPerson(ytelse, personQuery(id),
+                new PersonResponseProjection().kjoenn(new KjoennResponseProjection().kjoenn()))
+            .getKjoenn()
+            .stream()
+            .anyMatch(k -> KjoennType.MANN.equals(k.getKjoenn()));
     }
 
     @Override

--- a/domene/src/test/java/no/nav/foreldrepenger/mottak/task/joark/HentDataFraJoarkTaskTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/mottak/task/joark/HentDataFraJoarkTaskTest.java
@@ -227,8 +227,7 @@ class HentDataFraJoarkTaskTest {
         dataWrapper.setTema(Tema.FORELDRE_OG_SVANGERSKAPSPENGER);
         dataWrapper.setBehandlingTema(BehandlingTema.SVANGERSKAPSPENGER);
         var dokument = joarkTestsupport.lagArkivJournalpostStrukturert(DokumentTypeId.INNTEKTSMELDING, "testsoknader/inntektsmelding-far-svp.xml");
-        String fnrPåInntektsmelding = "99999999999";
-        doReturn(Optional.of(fnrPåInntektsmelding)).when(aktørConsumer).hentPersonIdentForAktørId(JoarkTestsupport.AKTØR_ID);
+        doReturn(Boolean.TRUE).when(aktørConsumer).erMann(BehandlingTema.SVANGERSKAPSPENGER, JoarkTestsupport.AKTØR_ID);
         when(arkivTjeneste.hentArkivJournalpost(ARKIV_ID)).thenReturn(dokument);
 
         MottakMeldingDataWrapper resultat = doTaskWithPrecondition(dataWrapper);


### PR DESCRIPTION
Være klar til år 2032 når man ikke lenger kan utlede kjønn fra PersonIdent (FNR/DNR)

Håndtere tilfelle der journalpost tilhører annet Tema når den behandles
* Oppstår gjerne ved journalføring på annen sak (eksternRef blir da null) og så endrer Tema (til noe annet enn FOR) 
* Dette gir 2 journalHendselser Mottatt og TemaEndret gjerne svært tett på hverandre
* Ikke prøve lese ORIGINAL (får tilgangsnekt)
* Ikke lage journalføringsoppgave hos oss
* Ses i lys av kommende tjeneste for å opprette oppgaver for uhåndterte journalposter uten oppgave