### PR TITLE
Mangel: fleksibelt uttak gjelder foreldrepenger

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/fordel/kodeverdi/DokumentTypeId.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/fordel/kodeverdi/DokumentTypeId.java
@@ -228,6 +228,10 @@ public enum DokumentTypeId implements Kodeverdi {
         return SØKNAD_TYPER.contains(kode);
     }
 
+    public static boolean erEndringssøknadType(DokumentTypeId kode) {
+        return ENDRING_SØKNAD_TYPER.contains(kode);
+    }
+
     public static boolean erKlageType(DokumentTypeId kode) {
         return KLAGE_TYPER.contains(kode);
     }

--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/ManuellOpprettSakValidator.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/ManuellOpprettSakValidator.java
@@ -46,7 +46,7 @@ public class ManuellOpprettSakValidator {
     private static FagsakYtelseTypeDto utledYtelseTypeFor(DokumentTypeId dokumentTypeId) {
         return switch (dokumentTypeId) {
             case SØKNAD_ENGANGSSTØNAD_ADOPSJON, SØKNAD_ENGANGSSTØNAD_FØDSEL -> FagsakYtelseTypeDto.ENGANGSTØNAD;
-            case SØKNAD_FORELDREPENGER_ADOPSJON, SØKNAD_FORELDREPENGER_FØDSEL -> FagsakYtelseTypeDto.FORELDREPENGER;
+            case SØKNAD_FORELDREPENGER_ADOPSJON, SØKNAD_FORELDREPENGER_FØDSEL, FLEKSIBELT_UTTAK_FORELDREPENGER, FORELDREPENGER_ENDRING_SØKNAD -> FagsakYtelseTypeDto.FORELDREPENGER;
             case SØKNAD_SVANGERSKAPSPENGER -> FagsakYtelseTypeDto.SVANGERSKAPSPENGER;
             default -> null;
         };

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/FerdigstillJournalføringTjeneste.java
@@ -292,7 +292,7 @@ public class FerdigstillJournalføringTjeneste {
     }
 
     String opprettSak(ArkivJournalpost journalpost, FerdigstillJournalføringRestTjeneste.OpprettSak opprettSakInfo, DokumentTypeId nyDokumentTypeId) {
-        new ManuellOpprettSakValidator(arkivTjeneste).validerKonsistensMedSakJP(journalpost, opprettSakInfo.ytelseType(), opprettSakInfo.aktørId(),
+        new ManuellOpprettSakValidator(arkivTjeneste).validerKonsistensForOpprettSak(journalpost, opprettSakInfo.ytelseType(), opprettSakInfo.aktørId(),
             nyDokumentTypeId);
 
         return fagsak.opprettSak(opprettSakRequest(journalpost.getJournalpostId(), opprettSakInfo)).getSaksnummer();
@@ -302,7 +302,7 @@ public class FerdigstillJournalføringTjeneste {
     String opprettNySak(ArkivJournalpost journalpost,
                         FerdigstillJournalføringRestTjeneste.OpprettSak opprettSakInfo,
                         DokumentTypeId nyDokumentTypeId) {
-        new ManuellOpprettSakValidator(arkivTjeneste).validerKonsistensMedSakJP(journalpost, opprettSakInfo.ytelseType(), opprettSakInfo.aktørId(),
+        new ManuellOpprettSakValidator(arkivTjeneste).validerKonsistensForOpprettSak(journalpost, opprettSakInfo.ytelseType(), opprettSakInfo.aktørId(),
             nyDokumentTypeId);
 
         return fagsak.opprettSak(opprettSakRequest(null, opprettSakInfo)).getSaksnummer();
@@ -334,7 +334,7 @@ public class FerdigstillJournalføringTjeneste {
 
         validerKanJournalføreKlageDokument(behandlingTemaFagsak, brukDokumentTypeId, dokumentKategori);
 
-        new ManuellOpprettSakValidator(arkivTjeneste).validerKonsistensMedSakJP(journalpost, behandlingTema.utledYtelseType(),
+        new ManuellOpprettSakValidator(arkivTjeneste).validerKonsistensForKnyttTilAnnenSak(journalpost, behandlingTema.utledYtelseType(),
             new AktørId(aktørIdFagsak), journalpost.getHovedtype());
 
         // Do the business


### PR DESCRIPTION
Ender opp i en et svart hull for validering - DokumentTypeId.erSøknadType(hovedDokumentType) er sann, men den klarer ikke utlede ytelse fra dokument i neste steg.
Skiller på validering for opprett ny sak (må ha førstegangssøknad) og validering for knyttTilAnnenSak (takler endringssøknad)