### PR TITLE
TFP-6070 hindre saksoppretting fra endelig journalført dok

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/ManuellOpprettSakValidator.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/ManuellOpprettSakValidator.java
@@ -13,6 +13,7 @@ import no.nav.foreldrepenger.journalføring.domene.JournalpostId;
 import no.nav.foreldrepenger.mottak.journal.ArkivJournalpost;
 import no.nav.foreldrepenger.mottak.journal.ArkivTjeneste;
 import no.nav.foreldrepenger.mottak.klient.FagsakYtelseTypeDto;
+import no.nav.foreldrepenger.mottak.tjeneste.DestinasjonsRuter;
 import no.nav.foreldrepenger.typer.AktørId;
 import no.nav.vedtak.exception.FunksjonellException;
 
@@ -71,7 +72,7 @@ public class ManuellOpprettSakValidator {
             hovedDokumentType = nyDokumentTypeId;
         }
 
-        if (nySak && !DokumentTypeId.erFørsteSøknadType(hovedDokumentType) && !DokumentTypeId.INNTEKTSMELDING.equals(hovedDokumentType)) {
+        if (nySak && !DestinasjonsRuter.kanOppretteSakFraDokument(hovedDokumentType)) {
             LOG.info("Prøver å opprette sak basert på journalpost {} type {}", arkivJournalpost.getJournalpostId(), hovedDokumentType.getTermNavn());
             throw new FunksjonellException("FP-785360", "Kan ikke opprette sak basert på valgt journalpost",
                 "Kan bare opprette sak fra førstegangssøknad eller inntektsmelding");

--- a/domene/src/main/java/no/nav/foreldrepenger/journalføring/ManuellOpprettSakValidator.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/journalføring/ManuellOpprettSakValidator.java
@@ -71,6 +71,12 @@ public class ManuellOpprettSakValidator {
             hovedDokumentType = nyDokumentTypeId;
         }
 
+        if (nySak && !DokumentTypeId.erFørsteSøknadType(hovedDokumentType) && !DokumentTypeId.INNTEKTSMELDING.equals(hovedDokumentType)) {
+            LOG.info("Prøver å opprette sak basert på journalpost {} type {}", arkivJournalpost.getJournalpostId(), hovedDokumentType.getTermNavn());
+            throw new FunksjonellException("FP-785360", "Kan ikke opprette sak basert på valgt journalpost",
+                "Kan bare opprette sak fra førstegangssøknad eller inntektsmelding");
+        }
+
         FagsakYtelseTypeDto journalpostFagsakYtelseTypeDto = null;
 
         if (DokumentTypeId.erSøknadType(hovedDokumentType)) {

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/task/joark/HentDataFraJoarkTask.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/task/joark/HentDataFraJoarkTask.java
@@ -249,7 +249,7 @@ public class HentDataFraJoarkTask extends WrappedProsessTaskHandler {
                 journalpost.getKanal(), journalpost.getHovedtype());
             return w.nesteSteg(TASK_GOSYS);
         } else {
-            if (destinasjon.saksnummer() == null && !vurderVLSaker.kanOppretteSak(w)) {
+            if (destinasjon.saksnummer() == null && DestinasjonsRuter.erKlageEllerAnke(w)) {
                 LOG.info("FPFORDEL HentFraArkiv kan ikke opprette sak - til GOSYS journalpost {} kanal {} dokumenttype {}",
                     journalpost.getJournalpostId(), journalpost.getKanal(), journalpost.getHovedtype());
                 return w.nesteSteg(TASK_GOSYS);

--- a/domene/src/main/java/no/nav/foreldrepenger/mottak/tjeneste/DestinasjonsRuter.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/mottak/tjeneste/DestinasjonsRuter.java
@@ -1,10 +1,8 @@
 package no.nav.foreldrepenger.mottak.tjeneste;
 
 import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentKategori.KLAGE_ELLER_ANKE;
-import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.INNTEKTSMELDING;
 import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.KLAGE_DOKUMENT;
 import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.UDEFINERT;
-import static no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId.erFørsteSøknadType;
 
 import java.time.LocalDate;
 import java.util.Comparator;
@@ -13,8 +11,8 @@ import java.util.stream.Stream;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
-
 import no.nav.foreldrepenger.fordel.kodeverdi.DokumentKategori;
+import no.nav.foreldrepenger.fordel.kodeverdi.DokumentTypeId;
 import no.nav.foreldrepenger.fordel.konfig.KonfigVerdier;
 import no.nav.foreldrepenger.kontrakter.fordel.OpprettSakDto;
 import no.nav.foreldrepenger.mottak.felles.MottakMeldingDataWrapper;
@@ -60,7 +58,7 @@ public class DestinasjonsRuter {
             .orElse(Tid.TIDENES_ENDE);
     }
 
-    private static boolean erKlageEllerAnke(MottakMeldingDataWrapper data) {
+    public static boolean erKlageEllerAnke(MottakMeldingDataWrapper data) {
         return (KLAGE_DOKUMENT.equals(data.getDokumentTypeId().orElse(UDEFINERT)) || KLAGE_ELLER_ANKE.equals(
             data.getDokumentKategori().orElse(DokumentKategori.UDEFINERT)));
     }
@@ -88,7 +86,7 @@ public class DestinasjonsRuter {
 
     public String opprettSak(MottakMeldingDataWrapper w) {
         var dokumenttype = w.getDokumentTypeId().orElseThrow();
-        if (!erFørsteSøknadType(dokumenttype) && !INNTEKTSMELDING.equals(dokumenttype)) {
+        if (!kanOppretteSakFraDokument(dokumenttype)) {
             throw new IllegalArgumentException("Kan ikke opprette sak for dokument");
         }
         var saksnummerDto = fagsakRestKlient.opprettSak(
@@ -97,7 +95,7 @@ public class DestinasjonsRuter {
         return saksnummerDto.getSaksnummer();
     }
 
-    public boolean kanOppretteSak(MottakMeldingDataWrapper w) {
-        return !erKlageEllerAnke(w);
+    public static boolean kanOppretteSakFraDokument(DokumentTypeId dokumenttype) {
+        return DokumentTypeId.erFørsteSøknadType(dokumenttype) || DokumentTypeId.INNTEKTSMELDING.equals(dokumenttype);
     }
 }

--- a/domene/src/test/java/no/nav/foreldrepenger/mottak/task/joark/HentDataFraJoarkTaskTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/mottak/task/joark/HentDataFraJoarkTaskTest.java
@@ -104,7 +104,6 @@ class HentDataFraJoarkTaskTest {
         when(arkivTjeneste.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
         when(vurderVLSaker.bestemDestinasjon(any())).thenReturn(Destinasjon.FPSAK_UTEN_SAK);
         when(vurderVLSaker.opprettSak(any())).thenReturn("456");
-        when(vurderVLSaker.kanOppretteSak(any())).thenReturn(true);
 
         MottakMeldingDataWrapper resultat = doTaskWithPrecondition(dataWrapper);
 
@@ -120,7 +119,6 @@ class HentDataFraJoarkTaskTest {
         when(arkivTjeneste.oppdaterRettMangler(any(), any(), any(), any())).thenReturn(true);
         when(vurderVLSaker.bestemDestinasjon(any())).thenReturn(Destinasjon.FPSAK_UTEN_SAK);
         when(vurderVLSaker.opprettSak(any())).thenReturn("789");
-        when(vurderVLSaker.kanOppretteSak(any())).thenReturn(true);
 
         MottakMeldingDataWrapper resultat = doTaskWithPrecondition(dataWrapper);
 
@@ -186,7 +184,6 @@ class HentDataFraJoarkTaskTest {
         var dokument = joarkTestsupport.lagJArkivJournalpostKlage();
         when(arkivTjeneste.hentArkivJournalpost(ARKIV_ID)).thenReturn(dokument);
         when(vurderVLSaker.bestemDestinasjon(any())).thenReturn(Destinasjon.GOSYS);
-        when(vurderVLSaker.kanOppretteSak(any())).thenReturn(false);
 
         MottakMeldingDataWrapper resultat = doTaskWithPrecondition(dataWrapper);
 
@@ -215,7 +212,6 @@ class HentDataFraJoarkTaskTest {
         when(arkivTjeneste.hentArkivJournalpost(ARKIV_ID)).thenReturn(dokument);
         when(vurderVLSaker.bestemDestinasjon(any())).thenReturn(Destinasjon.FPSAK_UTEN_SAK);
         when(vurderVLSaker.opprettSak(any())).thenReturn("123");
-        when(vurderVLSaker.kanOppretteSak(any())).thenReturn(true);
 
         MottakMeldingDataWrapper resultat = doTaskWithPrecondition(dataWrapper);
 

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/JournalføringRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/JournalføringRestTjeneste.java
@@ -14,6 +14,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import no.nav.foreldrepenger.mottak.tjeneste.DestinasjonsRuter;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -274,6 +276,7 @@ public class JournalføringRestTjeneste {
             journalpost.getJournalfoerendeEnhet().orElse(null),
             mapYtelseTypeTilDto(journalpost.getBehandlingstema().utledYtelseType()), eksisterendeSaksnummer,
             mapDokumenter(journalpost.getJournalpostId(), journalpost.getOriginalJournalpost().dokumenter()),
+            DestinasjonsRuter.kanOppretteSakFraDokument(journalpost.getHovedtype()),
             mapBrukersFagsaker(journalpost.getBrukerAktørId().orElse(null)));
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/JournalpostDetaljerDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fordel/web/app/rest/journalføring/JournalpostDetaljerDto.java
@@ -22,6 +22,7 @@ public record JournalpostDetaljerDto(@NotNull String journalpostId,
                                      @Valid YtelseTypeDto ytelseType,
                                      String eksisterendeSaksnummer,
                                      @NotNull @Valid @Size(min = 1) Set<DokumentDto> dokumenter,
+                                     boolean kanOppretteSak,
                                      @Valid List<SakJournalføringDto> fagsaker) {
 
     public record BrukerDto(@NotNull String navn, @NotNull String fnr, @NotNull String aktørId) {


### PR DESCRIPTION
Det aktuelle tilfellet traff if (jp.tilstand.erEndelig) og Log "Prøver å journalføre et dokument med tema".

Legger til en eksplisitt sperre mot å opprette sak basert på annet enn førstegang og inntektsmelding. 