### PR TITLE
chore: Oppdater mottakskanaler og tillat lengre navn

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/fordel/kodeverdi/MottakKanal.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/fordel/kodeverdi/MottakKanal.java
@@ -17,7 +17,9 @@ public enum MottakKanal implements Kodeverdi {
     EPOST("E_POST"),
     HELSENETTET("HELSENETTET"),
     SKAN_NETS("SKAN_NETS"), // Ubrukt siden 2020
+    SKAN_PEN("SKAN_PEN"), // Scanning pensjon, skal ikke være relevant
     SKAN_IM("SKAN_IM"), // Iron Mountain, ikke inntektsmelding
+    HR_SYSTEM_API("HR_SYSTEM_API"), // Inntektsmelding sendt fra HR-system direkte til Nav-API
 
     /**
      * Alle kodeverk må ha en verdi, det kan ikke være null i databasen. Denne koden

--- a/migreringer/src/main/resources/db/migration/defaultDS/3.1/V3.1_02__chore_lange_mottakskanalnavn.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/3.1/V3.1_02__chore_lange_mottakskanalnavn.sql
@@ -1,0 +1,1 @@
+alter table JOURNALPOST modify KANAL varchar2(50 char) ;


### PR DESCRIPTION
Vi mellomlagrer en del journalposter for å filtrere innkommende kafka. 
Tar med nyeste kanal-navn (Sykepenger IM-api) og tillater lengre kanalnavn.